### PR TITLE
fix: strip markdown code blocks from LLM responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-01-10
+
+### Fixed
+
+- Fixed JSON parsing errors when LLM models return responses wrapped in markdown code blocks (e.g., \`\`\`json ... \`\`\`)
+
 ## [0.3.4] - 2026-01-10
 
 ### Changed
@@ -145,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Django 4.2, 5.0, 5.1, 5.2, and 6.0
 - Support for Python 3.9 through 3.14
 
+[0.3.5]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.1...v0.3.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "0.3.4"
+version = "0.3.5"
 description = "Stop copy-pasting to and from Google Translate. Translate your Django .po files automatically with AI."
 authors = [
   { name = "Bjorn the Builder" },

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import polib
 import tiktoken
@@ -72,6 +73,9 @@ def translate_text(text, target_lang, model, api_key):
     content = content.strip()
     if not content:
         raise ValueError(f"API returned empty content after stripping. Model: {model}")
+
+    # Strip markdown code blocks if present (some models wrap JSON in ```json ... ```)
+    content = re.sub(r"^```\w*\n?(.*?)\n?```$", r"\1", content, flags=re.DOTALL).strip()
 
     try:
         translated = json.loads(content)

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -200,6 +200,36 @@ def test_translate_text_batch(mocker):
     mock_completion.assert_called_once()
 
 
+def test_translate_text_strips_markdown_code_blocks(mocker):
+    """Test that markdown code blocks are stripped from API responses."""
+    mock_response = mocker.MagicMock()
+    mock_response.choices[0].message.content = '```json\n["Hallo, wereld!"]\n```'
+
+    mock_completion = mocker.patch(
+        "translatebot_django.management.commands.translate.completion"
+    )
+    mock_completion.return_value = mock_response
+
+    result = translate_text(["Hello, world!"], "nl", "gpt-4o-mini", "test-api-key")
+
+    assert result == ["Hallo, wereld!"]
+
+
+def test_translate_text_strips_markdown_code_blocks_no_lang(mocker):
+    """Test that markdown code blocks without language tag are stripped."""
+    mock_response = mocker.MagicMock()
+    mock_response.choices[0].message.content = '```\n["Hallo"]\n```'
+
+    mock_completion = mocker.patch(
+        "translatebot_django.management.commands.translate.completion"
+    )
+    mock_completion.return_value = mock_response
+
+    result = translate_text(["Hello"], "nl", "gpt-4o-mini", "test-api-key")
+
+    assert result == ["Hallo"]
+
+
 def test_command_requires_target_lang(settings):
     """Test that command requires --target-lang when LANGUAGES is not defined."""
     # Ensure LANGUAGES is not defined

--- a/uv.lock
+++ b/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "0.3.0"
+version = "0.3.5"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Some LLM models wrap JSON responses in markdown code blocks (e.g., ```json ... ```). This caused JSON parsing errors.