### PR TITLE
fix: extract JSON array from LLM responses with preamble text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.6] - 2026-01-10
+
+### Fixed
+
+- Fixed JSON parsing when LLM adds preamble text before the JSON array (e.g., "Here is the translation:")
+
 ## [0.3.5] - 2026-01-10
 
 ### Fixed
@@ -151,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Django 4.2, 5.0, 5.1, 5.2, and 6.0
 - Support for Python 3.9 through 3.14
 
+[0.3.6]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/gettranslatebot/translatebot-django/compare/v0.3.2...v0.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "0.3.5"
+version = "0.3.6"
 description = "Stop copy-pasting to and from Google Translate. Translate your Django .po files automatically with AI."
 authors = [
   { name = "Bjorn the Builder" },

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import polib
 import tiktoken
@@ -74,8 +73,11 @@ def translate_text(text, target_lang, model, api_key):
     if not content:
         raise ValueError(f"API returned empty content after stripping. Model: {model}")
 
-    # Strip markdown code blocks if present (some models wrap JSON in ```json ... ```)
-    content = re.sub(r"^```\w*\n?(.*?)\n?```$", r"\1", content, flags=re.DOTALL).strip()
+    # Extract JSON array if LLM added preamble text or wrapped in code blocks
+    start = content.find("[")
+    end = content.rfind("]")
+    if start != -1 and end != -1:
+        content = content[start : end + 1]
 
     try:
         translated = json.loads(content)

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -200,10 +200,10 @@ def test_translate_text_batch(mocker):
     mock_completion.assert_called_once()
 
 
-def test_translate_text_strips_markdown_code_blocks(mocker):
-    """Test that markdown code blocks are stripped from API responses."""
+def test_translate_text_extracts_json_from_preamble(mocker):
+    """Test that JSON is extracted when LLM adds preamble text."""
     mock_response = mocker.MagicMock()
-    mock_response.choices[0].message.content = '```json\n["Hallo, wereld!"]\n```'
+    mock_response.choices[0].message.content = 'Preamble text:\n["Hallo, wereld!"]'
 
     mock_completion = mocker.patch(
         "translatebot_django.management.commands.translate.completion"
@@ -215,10 +215,10 @@ def test_translate_text_strips_markdown_code_blocks(mocker):
     assert result == ["Hallo, wereld!"]
 
 
-def test_translate_text_strips_markdown_code_blocks_no_lang(mocker):
-    """Test that markdown code blocks without language tag are stripped."""
+def test_translate_text_extracts_json_from_code_block(mocker):
+    """Test that JSON is extracted from markdown code blocks."""
     mock_response = mocker.MagicMock()
-    mock_response.choices[0].message.content = '```\n["Hallo"]\n```'
+    mock_response.choices[0].message.content = '```json\n["Hallo"]\n```'
 
     mock_completion = mocker.patch(
         "translatebot_django.management.commands.translate.completion"

--- a/uv.lock
+++ b/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "0.3.5"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
Some LLMs add explanatory text before the JSON array (e.g., "Here is the translation:") or wrap it in markdown code blocks. This change uses a simpler approach: find the first `[` and last `]` to extract the JSON array, handling both cases without regex.