### PR TITLE
feat: add TRANSLATING.md support for project-specific translation con…

### DIFF
--- a/src/translatebot_django/utils.py
+++ b/src/translatebot_django/utils.py
@@ -121,3 +121,38 @@ def get_modeltranslation_translator():
     from modeltranslation.translator import translator
 
     return translator
+
+
+def get_translation_context():
+    """
+    Find and read the TRANSLATING.md file from the project root.
+
+    This file allows users to provide context about their project
+    that will be included in the system prompt sent to the LLM,
+    helping to improve translation quality.
+
+    Returns:
+        str or None: The contents of TRANSLATING.md if found, None otherwise.
+    """
+    # Look for TRANSLATING.md in the project root (where manage.py typically is)
+    # Try settings.BASE_DIR first, then fall back to current directory
+    search_paths = []
+
+    # Try BASE_DIR from settings
+    base_dir = getattr(settings, "BASE_DIR", None)
+    if base_dir:
+        search_paths.append(Path(base_dir))
+
+    # Also try current working directory as fallback
+    search_paths.append(Path.cwd())
+
+    for base_path in search_paths:
+        context_file = base_path / "TRANSLATING.md"
+        if context_file.exists():
+            try:
+                return context_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                # If we can't read the file for some reason, skip it
+                continue
+
+    return None

--- a/tests/test_modeltranslation_integration.py
+++ b/tests/test_modeltranslation_integration.py
@@ -201,7 +201,7 @@ def test_translate_command_models_batching(settings, mock_env_api_key, mocker):
     # Mock translate_text to return translations for each batch
     translate_mock = mocker.patch(
         "translatebot_django.management.commands.translate.translate_text",
-        side_effect=lambda text, _target_lang, _model, _api_key: [
+        side_effect=lambda text, _target_lang, _model, _api_key, **_kwargs: [
             f"Translated {i}" for i in range(len(text))
         ],
     )


### PR DESCRIPTION
…text

Add ability for users to provide project-specific context for translations by placing a TRANSLATING.md file in the project root. This context is included in the LLM system prompt to improve translation quality.

- Add get_translation_context() utility to find and read TRANSLATING.md
- Update translate_text() to accept optional context parameter
- Build dynamic system prompt that includes project context when available
- Display message when TRANSLATING.md is found
- Add comprehensive tests for all new functionality