### PR TITLE
fix: batching off-by-one error in PO and model translation paths

### DIFF
--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -402,11 +402,11 @@ class Command(BaseCommand):
                 if total + preamble_length + output_tokens_estimate > get_max_tokens(
                     model
                 ):
-                    groups.append(group_candidate)
-                    group_candidate = []
+                    if len(group_candidate) > 1:
+                        groups.append(group_candidate[:-1])
+                    group_candidate = [item]
 
-            if group_candidate:
-                groups.append(group_candidate)
+            groups.append(group_candidate)
 
             if dry_run:
                 for group in groups:
@@ -565,7 +565,8 @@ class Command(BaseCommand):
 
             if total + preamble_length + output_tokens_estimate > get_max_tokens(model):
                 # Group is full, save it and start a new one
-                groups.append((group_candidate[:-1], group_items[:-1]))
+                if len(group_candidate) > 1:
+                    groups.append((group_candidate[:-1], group_items[:-1]))
                 group_candidate = [item["source_text"]]
                 group_items = [item]
 


### PR DESCRIPTION
The PO file batching loop included the overflowing item in the current group instead of carrying it to the next batch. This could cause groups to exceed token limits.

Also added an empty-group guard to the model translation batching path which already split correctly but could append empty groups when a single item exceeds the token limit.