### PR TITLE
feat: add DeepL translation provider (#66)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ dev = [
   "pytest-cov>=4.0.0",
   "ruff>=0.8.0",
   "django-modeltranslation>=0.18",
+  "deepl>=1.0.0",
+]
+deepl = [
+  "deepl>=1.0.0",
 ]
 modeltranslation = [
   "django-modeltranslation>=0.18",

--- a/src/translatebot_django/providers/__init__.py
+++ b/src/translatebot_django/providers/__init__.py
@@ -1,0 +1,75 @@
+from abc import ABC, abstractmethod
+
+from django.core.management.base import CommandError
+
+
+class TranslationProvider(ABC):
+    """Abstract base class for translation providers."""
+
+    @abstractmethod
+    def translate(self, texts, target_lang, context=None):
+        """Translate a batch of texts to the target language.
+
+        Args:
+            texts: List of strings to translate.
+            target_lang: Target language code (e.g., 'nl', 'de').
+            context: Optional translation context from TRANSLATING.md.
+
+        Returns:
+            List of translated strings, same length as texts.
+        """
+
+    @abstractmethod
+    def batch(self, texts, target_lang):
+        """Split texts into batches suitable for this provider.
+
+        Args:
+            texts: List of strings to split into batches.
+            target_lang: Target language code.
+
+        Returns:
+            List of lists of strings.
+        """
+
+    @property
+    @abstractmethod
+    def name(self):
+        """Display name for this provider (e.g., 'gpt-4o-mini', 'DeepL')."""
+
+    @property
+    @abstractmethod
+    def supports_context(self):
+        """Whether this provider can use TRANSLATING.md context."""
+
+
+def get_provider(api_key):
+    """Create a translation provider based on Django settings.
+
+    Reads TRANSLATEBOT_PROVIDER from settings. Defaults to 'litellm' if not set.
+
+    Args:
+        api_key: API key for the provider.
+
+    Returns:
+        A TranslationProvider instance.
+    """
+    from django.conf import settings
+
+    provider_name = getattr(settings, "TRANSLATEBOT_PROVIDER", "litellm")
+
+    if provider_name == "litellm":
+        from translatebot_django.providers.litellm import LiteLLMProvider
+        from translatebot_django.utils import get_model
+
+        model = get_model()
+        return LiteLLMProvider(model=model, api_key=api_key)
+
+    if provider_name == "deepl":
+        from translatebot_django.providers.deepl import DeepLProvider
+
+        return DeepLProvider(api_key=api_key)
+
+    raise CommandError(
+        f"Unknown translation provider: '{provider_name}'. "
+        "Supported providers: 'litellm', 'deepl'."
+    )

--- a/src/translatebot_django/providers/deepl.py
+++ b/src/translatebot_django/providers/deepl.py
@@ -1,0 +1,119 @@
+from django.core.management.base import CommandError
+
+from translatebot_django.providers import TranslationProvider
+
+# DeepL API limits
+MAX_TEXTS_PER_REQUEST = 50
+MAX_REQUEST_SIZE_BYTES = 128 * 1024  # 128 KB
+
+# Language codes that need region suffixes for DeepL
+# DeepL requires specific regional variants for these target languages
+_DEEPL_REGIONAL_TARGETS = {
+    "en": "EN-US",
+    "pt": "PT-BR",
+}
+
+
+def django_to_deepl_target(lang_code):
+    """Convert a Django language code to a DeepL target language code.
+
+    Examples:
+        'en' -> 'EN-US'
+        'de' -> 'DE'
+        'pt-br' -> 'PT-BR'
+        'zh-hans' -> 'ZH-HANS'
+    """
+    # Check if this is a base language that needs a regional default
+    lower = lang_code.lower()
+    if lower in _DEEPL_REGIONAL_TARGETS:
+        return _DEEPL_REGIONAL_TARGETS[lower]
+
+    # Django uses lowercase with hyphens (e.g. 'pt-br', 'zh-hans')
+    # DeepL uses uppercase with hyphens (e.g. 'PT-BR', 'ZH-HANS')
+    return lang_code.upper()
+
+
+def _get_deepl_module():
+    """Import and return the deepl module, raising CommandError if not installed."""
+    try:
+        import deepl
+
+        return deepl
+    except ImportError as e:
+        raise CommandError(
+            "The 'deepl' package is required to use the DeepL provider.\n"
+            "Install it with: pip install translatebot-django[deepl]"
+        ) from e
+
+
+class DeepLProvider(TranslationProvider):
+    """Translation provider using the DeepL API."""
+
+    def __init__(self, api_key):
+        self._deepl = _get_deepl_module()
+        self._translator = self._deepl.Translator(api_key)
+
+    def translate(self, texts, target_lang, context=None):
+        deepl_lang = django_to_deepl_target(target_lang)
+
+        try:
+            results = self._translator.translate_text(texts, target_lang=deepl_lang)
+        except self._deepl.AuthorizationException as e:
+            raise CommandError(
+                f"DeepL authentication failed: {e}\n"
+                "Please check your API key configuration.\n"
+                "Set TRANSLATEBOT_API_KEY in settings or "
+                "TRANSLATEBOT_API_KEY environment variable."
+            ) from e
+        except self._deepl.QuotaExceededException as e:
+            raise CommandError(
+                "DeepL character quota exceeded. "
+                "Please check your DeepL plan usage at "
+                "https://www.deepl.com/account/usage"
+            ) from e
+        except self._deepl.TooManyRequestsException as e:
+            raise CommandError(
+                "DeepL rate limit exceeded. Please wait and try again."
+            ) from e
+        except self._deepl.DeepLException as e:
+            raise CommandError(f"DeepL API error: {e}") from e
+
+        return [r.text for r in results]
+
+    def batch(self, texts, target_lang):
+        """Split texts into batches respecting DeepL API limits.
+
+        DeepL limits: max 50 texts per request, max 128KB total request size.
+        """
+        groups = []
+        current_group = []
+        current_size = 0
+
+        for text in texts:
+            text_size = len(text.encode("utf-8"))
+
+            would_exceed_count = len(current_group) >= MAX_TEXTS_PER_REQUEST
+            would_exceed_size = (
+                current_group and current_size + text_size > MAX_REQUEST_SIZE_BYTES
+            )
+
+            if would_exceed_count or would_exceed_size:
+                groups.append(current_group)
+                current_group = []
+                current_size = 0
+
+            current_group.append(text)
+            current_size += text_size
+
+        if current_group:
+            groups.append(current_group)
+
+        return groups
+
+    @property
+    def name(self):
+        return "DeepL"
+
+    @property
+    def supports_context(self):
+        return False

--- a/src/translatebot_django/providers/litellm.py
+++ b/src/translatebot_django/providers/litellm.py
@@ -1,0 +1,33 @@
+from translatebot_django.providers import TranslationProvider
+
+
+class LiteLLMProvider(TranslationProvider):
+    """Translation provider using LiteLLM (OpenAI, Anthropic, etc.)."""
+
+    def __init__(self, model, api_key):
+        self._model = model
+        self._api_key = api_key
+
+    def translate(self, texts, target_lang, context=None):
+        from translatebot_django.management.commands.translate import translate_text
+
+        return translate_text(
+            text=texts,
+            target_lang=target_lang,
+            model=self._model,
+            api_key=self._api_key,
+            context=context,
+        )
+
+    def batch(self, texts, target_lang):
+        from translatebot_django.management.commands.translate import batch_by_tokens
+
+        return batch_by_tokens(texts, target_lang, self._model)
+
+    @property
+    def name(self):
+        return self._model
+
+    @property
+    def supports_context(self):
+        return True

--- a/tests/test_modeltranslation_integration.py
+++ b/tests/test_modeltranslation_integration.py
@@ -201,7 +201,7 @@ def test_translate_command_models_batching(settings, mock_env_api_key, mocker):
     # Mock translate_text to return translations for each batch
     translate_mock = mocker.patch(
         "translatebot_django.management.commands.translate.translate_text",
-        side_effect=lambda text, _target_lang, _model, _api_key, **_kwargs: [
+        side_effect=lambda text, **_kwargs: [
             f"Translated {i}" for i in range(len(text))
         ],
     )

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,346 @@
+"""Tests for translation providers."""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+from django.core.management.base import CommandError
+
+# --- Factory tests ---
+
+
+def test_get_provider_default_is_litellm(settings, monkeypatch):
+    """Default provider (no setting) returns LiteLLMProvider."""
+    monkeypatch.setenv("TRANSLATEBOT_API_KEY", "test-key")
+    if hasattr(settings, "TRANSLATEBOT_PROVIDER"):
+        delattr(settings, "TRANSLATEBOT_PROVIDER")
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    from translatebot_django.providers import get_provider
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    provider = get_provider("test-key")
+    assert isinstance(provider, LiteLLMProvider)
+
+
+def test_get_provider_explicit_litellm(settings):
+    """Explicit litellm setting returns LiteLLMProvider."""
+    settings.TRANSLATEBOT_PROVIDER = "litellm"
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    from translatebot_django.providers import get_provider
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    provider = get_provider("test-key")
+    assert isinstance(provider, LiteLLMProvider)
+
+
+def test_get_provider_deepl(settings):
+    """DeepL setting returns DeepLProvider."""
+    settings.TRANSLATEBOT_PROVIDER = "deepl"
+
+    from translatebot_django.providers import get_provider
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = get_provider("test-key")
+    assert isinstance(provider, DeepLProvider)
+
+
+def test_get_provider_unknown_raises_error(settings):
+    """Unknown provider name raises CommandError."""
+    settings.TRANSLATEBOT_PROVIDER = "unknown_provider"
+
+    from translatebot_django.providers import get_provider
+
+    with pytest.raises(CommandError, match="Unknown translation provider"):
+        get_provider("test-key")
+
+
+# --- LiteLLM provider property tests ---
+
+
+def test_litellm_provider_name(settings):
+    """LiteLLMProvider.name returns the model name."""
+    settings.TRANSLATEBOT_MODEL = "claude-3-sonnet"
+
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(model="claude-3-sonnet", api_key="test-key")
+    assert provider.name == "claude-3-sonnet"
+
+
+def test_litellm_provider_supports_context():
+    """LiteLLMProvider supports TRANSLATING.md context."""
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
+    assert provider.supports_context is True
+
+
+# --- DeepL provider property tests ---
+
+
+def test_deepl_provider_name():
+    """DeepLProvider.name returns 'DeepL'."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    assert provider.name == "DeepL"
+
+
+def test_deepl_provider_supports_context():
+    """DeepLProvider does not support TRANSLATING.md context."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    assert provider.supports_context is False
+
+
+# --- DeepL language code mapping tests ---
+
+
+def test_deepl_lang_mapping_simple():
+    """Simple language codes are uppercased."""
+    from translatebot_django.providers.deepl import django_to_deepl_target
+
+    assert django_to_deepl_target("de") == "DE"
+    assert django_to_deepl_target("fr") == "FR"
+    assert django_to_deepl_target("nl") == "NL"
+    assert django_to_deepl_target("ja") == "JA"
+
+
+def test_deepl_lang_mapping_english_default():
+    """'en' maps to 'EN-US' (DeepL requires a regional variant)."""
+    from translatebot_django.providers.deepl import django_to_deepl_target
+
+    assert django_to_deepl_target("en") == "EN-US"
+
+
+def test_deepl_lang_mapping_portuguese_default():
+    """'pt' maps to 'PT-BR' (DeepL requires a regional variant)."""
+    from translatebot_django.providers.deepl import django_to_deepl_target
+
+    assert django_to_deepl_target("pt") == "PT-BR"
+
+
+def test_deepl_lang_mapping_regional_variant():
+    """Regional variants like 'pt-br' are uppercased as-is."""
+    from translatebot_django.providers.deepl import django_to_deepl_target
+
+    assert django_to_deepl_target("pt-br") == "PT-BR"
+    assert django_to_deepl_target("zh-hans") == "ZH-HANS"
+    assert django_to_deepl_target("en-gb") == "EN-GB"
+
+
+# --- DeepL batching tests ---
+
+
+def test_deepl_batch_under_limit():
+    """Texts under both limits stay in a single batch."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    texts = ["Hello", "World", "Test"]
+    batches = provider.batch(texts, "de")
+    assert batches == [["Hello", "World", "Test"]]
+
+
+def test_deepl_batch_over_50_texts():
+    """More than 50 texts are split into multiple batches."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    texts = [f"String {i}" for i in range(120)]
+    batches = provider.batch(texts, "de")
+
+    assert len(batches) == 3  # 50 + 50 + 20
+    assert len(batches[0]) == 50
+    assert len(batches[1]) == 50
+    assert len(batches[2]) == 20
+
+    # All texts accounted for
+    flat = [t for batch in batches for t in batch]
+    assert flat == texts
+
+
+def test_deepl_batch_large_texts():
+    """Texts exceeding 128KB are split by size."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    # Each text is ~10KB, so 128KB limit fits ~12 texts
+    large_text = "A" * 10_000
+    texts = [large_text] * 20
+    batches = provider.batch(texts, "de")
+
+    assert len(batches) > 1
+    # Each batch should be at most 128KB
+    for batch in batches:
+        total_size = sum(len(t.encode("utf-8")) for t in batch)
+        assert total_size <= 128 * 1024
+
+
+def test_deepl_batch_empty():
+    """Empty input returns empty list."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    batches = provider.batch([], "de")
+    assert batches == []
+
+
+def test_deepl_batch_single_oversized_text():
+    """A single text larger than 128KB goes into its own batch."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    huge_text = "B" * (200 * 1024)  # 200KB
+    texts = ["small", huge_text, "also small"]
+    batches = provider.batch(texts, "de")
+
+    # "small" in first batch, huge_text overflows to second, "also small" in third
+    assert len(batches) == 3
+    assert batches[0] == ["small"]
+    assert batches[1] == [huge_text]
+    assert batches[2] == ["also small"]
+
+
+# --- DeepL translate tests ---
+
+
+def test_deepl_translate_basic(mocker):
+    """DeepLProvider.translate returns translated texts."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    mock_result_1 = MagicMock()
+    mock_result_1.text = "Hallo"
+    mock_result_2 = MagicMock()
+    mock_result_2.text = "Welt"
+
+    provider._translator.translate_text = MagicMock(
+        return_value=[mock_result_1, mock_result_2]
+    )
+
+    result = provider.translate(["Hello", "World"], "de")
+    assert result == ["Hallo", "Welt"]
+
+    provider._translator.translate_text.assert_called_once_with(
+        ["Hello", "World"], target_lang="DE"
+    )
+
+
+def test_deepl_translate_uses_mapped_lang(mocker):
+    """DeepLProvider.translate converts language codes for the API."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    mock_result = MagicMock()
+    mock_result.text = "Hello"
+
+    provider._translator.translate_text = MagicMock(return_value=[mock_result])
+
+    provider.translate(["Hi"], "en")
+
+    provider._translator.translate_text.assert_called_once_with(
+        ["Hi"], target_lang="EN-US"
+    )
+
+
+# --- DeepL error handling tests ---
+
+
+def test_deepl_translate_auth_error():
+    """DeepL auth error raises CommandError."""
+    import deepl
+
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="bad-key")
+    provider._translator.translate_text = MagicMock(
+        side_effect=deepl.AuthorizationException("Invalid auth key")
+    )
+
+    with pytest.raises(CommandError, match="DeepL authentication failed"):
+        provider.translate(["Hello"], "de")
+
+
+def test_deepl_translate_quota_error():
+    """DeepL quota error raises CommandError."""
+    import deepl
+
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    provider._translator.translate_text = MagicMock(
+        side_effect=deepl.QuotaExceededException("Quota exceeded")
+    )
+
+    with pytest.raises(CommandError, match="DeepL character quota exceeded"):
+        provider.translate(["Hello"], "de")
+
+
+def test_deepl_translate_rate_limit_error():
+    """DeepL rate limit error raises CommandError."""
+    import deepl
+
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    provider._translator.translate_text = MagicMock(
+        side_effect=deepl.TooManyRequestsException("Too many requests")
+    )
+
+    with pytest.raises(CommandError, match="DeepL rate limit exceeded"):
+        provider.translate(["Hello"], "de")
+
+
+def test_deepl_translate_generic_error():
+    """Generic DeepL API error raises CommandError."""
+    import deepl
+
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+    provider._translator.translate_text = MagicMock(
+        side_effect=deepl.DeepLException("Something went wrong")
+    )
+
+    with pytest.raises(CommandError, match="DeepL API error"):
+        provider.translate(["Hello"], "de")
+
+
+# --- DeepL import guard test ---
+
+
+def test_deepl_import_guard_raises_error(monkeypatch):
+    """Missing deepl package raises CommandError with install instructions."""
+    # Temporarily remove deepl from sys.modules
+    original = sys.modules.pop("deepl", None)
+    # Also remove our provider module so it re-imports
+    sys.modules.pop("translatebot_django.providers.deepl", None)
+
+    import builtins
+
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "deepl":
+            raise ImportError("No module named 'deepl'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    try:
+        from translatebot_django.providers.deepl import _get_deepl_module
+
+        with pytest.raises(CommandError, match="pip install translatebot-django"):
+            _get_deepl_module()
+    finally:
+        # Restore
+        if original:
+            sys.modules["deepl"] = original
+        sys.modules.pop("translatebot_django.providers.deepl", None)

--- a/uv.lock
+++ b/uv.lock
@@ -426,6 +426,18 @@ toml = [
 ]
 
 [[package]]
+name = "deepl"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/50/250fcdf450b35139df0521e2578eef898e4705ebb772680f9b782676f510/deepl-1.28.0.tar.gz", hash = "sha256:7b35816ca8ff40609746586145ec3e9d7c758b546f353ea73f24118e56a1fdad", size = 51260, upload-time = "2026-02-05T19:28:19.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/33/17c72c38d4f696a8de2af26a301235b99002e0cc5f9a2c4210f060d67290/deepl-1.28.0-py3-none-any.whl", hash = "sha256:d43ae248f74a81150765e303cc62aef7d2ddbf40f2d5454a6b4cf3f54ac69619", size = 46268, upload-time = "2026-02-05T19:28:17.783Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2078,7 +2090,11 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+deepl = [
+    { name = "deepl" },
+]
 dev = [
+    { name = "deepl" },
     { name = "django-modeltranslation" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -2092,6 +2108,8 @@ modeltranslation = [
 
 [package.metadata]
 requires-dist = [
+    { name = "deepl", marker = "extra == 'deepl'", specifier = ">=1.0.0" },
+    { name = "deepl", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "django", specifier = ">=4.2" },
     { name = "django-modeltranslation", marker = "extra == 'dev'", specifier = ">=0.18" },
     { name = "django-modeltranslation", marker = "extra == 'modeltranslation'", specifier = ">=0.18" },
@@ -2103,7 +2121,7 @@ requires-dist = [
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.10.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
 ]
-provides-extras = ["dev", "modeltranslation"]
+provides-extras = ["dev", "deepl", "modeltranslation"]
 
 [[package]]
 name = "typer-slim"


### PR DESCRIPTION
Introduce a TranslationProvider ABC with LiteLLM and DeepL implementations. The command now uses a provider abstraction, configured via the optional TRANSLATEBOT_PROVIDER setting (defaults to 'litellm' for full backward compatibility).

DeepL provider features:
- Language code mapping (en->EN-US, pt->PT-BR, etc.)
- Batching respecting DeepL limits (50 texts, 128KB)
- Auth, quota, rate limit, and generic error handling
- TRANSLATING.md warning for both project and per-app contexts
- Import guard with install instructions

Also extracts batch_by_tokens() as a reusable function and adds deepl as an optional dependency group.