### PR TITLE
feat: gracefully handle missing litellm so DeepL-only users can unins…

### DIFF
--- a/src/translatebot_django/providers/__init__.py
+++ b/src/translatebot_django/providers/__init__.py
@@ -58,6 +58,13 @@ def get_provider(api_key):
     provider_name = getattr(settings, "TRANSLATEBOT_PROVIDER", "litellm")
 
     if provider_name == "litellm":
+        from translatebot_django.management.commands.translate import (
+            _LITELLM_MISSING_MSG,
+            _has_litellm,
+        )
+
+        if not _has_litellm:
+            raise CommandError(_LITELLM_MISSING_MSG)
         from translatebot_django.providers.litellm import LiteLLMProvider
         from translatebot_django.utils import get_model
 


### PR DESCRIPTION
…tall it

Guard all litellm/tiktoken imports behind try/except ImportError so the package still works when a user manually removes litellm. Attempting to use an LLM provider without litellm raises a clear CommandError with install instructions.