### PR TITLE
fix: save translations after each batch to prevent data loss

### DIFF
--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -483,6 +483,34 @@ class Command(BaseCommand):
             )
             self.stdout.write("=" * 60)
 
+    @staticmethod
+    def _save_po_translations(po_paths, msgid_to_translation):
+        """Write current translations to PO files on disk.
+
+        Called after each successful batch so that translations are persisted
+        incrementally and not lost if a later batch fails.
+        """
+        for po_path in po_paths:
+            po = polib.pofile(str(po_path), wrapwidth=79)
+            changed = False
+
+            for entry in po:
+                if entry.msgid not in msgid_to_translation:
+                    continue
+                if entry.msgid_plural:
+                    singular = msgid_to_translation[entry.msgid]
+                    plural = msgid_to_translation.get(entry.msgid_plural, singular)
+                    for i in entry.msgstr_plural:
+                        entry.msgstr_plural[i] = singular if i == 0 else plural
+                else:
+                    entry.msgstr = msgid_to_translation[entry.msgid]
+                if entry.fuzzy:
+                    entry.flags.remove("fuzzy")
+                changed = True
+
+            if changed:
+                po.save(str(po_path))
+
     def _translate_po_files(
         self,
         target_lang,
@@ -544,7 +572,7 @@ class Command(BaseCommand):
                         msgid_to_translation[msgid] = ""
             else:
                 with handle_api_errors():
-                    for group in groups:
+                    for batch_num, group in enumerate(groups, 1):
                         batch_comments = {
                             t: all_comments[t] for t in group if t in all_comments
                         } or None
@@ -556,6 +584,11 @@ class Command(BaseCommand):
                         )
                         for msgid, translation in zip(group, translated, strict=True):
                             msgid_to_translation[msgid] = translation
+
+                        # Save PO files after each batch so translations
+                        # aren't lost if a later batch fails
+                        self._save_po_translations(group_po_paths, msgid_to_translation)
+                        self.stdout.write(f"  💾 Saved batch {batch_num}/{len(groups)}")
 
         # Early return with minimal output if nothing to translate
         if total_msgids == 0:
@@ -580,8 +613,7 @@ class Command(BaseCommand):
         else:
             self.stdout.write(f"🔄 Translating with {provider.name}...")
 
-        # Now we have all the msgid -> translation mappings, we can proceed
-        # with putting them into the .po files
+        # Report what was translated and save PO files for dry-run
         total_changed = 0
         for po_path in po_paths:
             self.stdout.write(self.style.NOTICE(f"\nProcessing: {po_path}"))
@@ -594,30 +626,17 @@ class Command(BaseCommand):
                         self.stdout.write(f"✓ Would translate '{entry.msgid[:50]}'")
                     else:
                         self.stdout.write(f"✓ Translated '{entry.msgid[:50]}'")
-                        if entry.msgid_plural:
-                            singular = msgid_to_translation[entry.msgid]
-                            plural = msgid_to_translation.get(
-                                entry.msgid_plural, singular
-                            )
-                            for i in entry.msgstr_plural:
-                                entry.msgstr_plural[i] = singular if i == 0 else plural
-                        else:
-                            entry.msgstr = msgid_to_translation[entry.msgid]
-                        # Clear fuzzy flag since we have a fresh translation
-                        if entry.fuzzy:
-                            entry.flags.remove("fuzzy")
                     changed += 1
 
-            if not dry_run and changed > 0:
-                po.save(str(po_path))
-                self.stdout.write(
-                    self.style.SUCCESS(f"✨ Successfully updated {po_path}")
-                )
-            elif dry_run:
+            if dry_run:
                 self.stdout.write(
                     self.style.NOTICE(
                         f"Dry run: {changed} entries would be updated in {po_path}"
                     )
+                )
+            elif changed > 0:
+                self.stdout.write(
+                    self.style.SUCCESS(f"✨ Successfully updated {po_path}")
                 )
 
             total_changed += changed
@@ -702,16 +721,7 @@ class Command(BaseCommand):
         # Translate all groups
         if dry_run:
             self.stdout.write("🔍 Dry run mode: skipping translation")
-            translation_items = []
-            for _texts_group, items_group in groups:
-                for item in items_group:
-                    translation_items.append(
-                        {
-                            "instance": item["instance"],
-                            "target_field": item["target_field"],
-                            "translation": "",
-                        }
-                    )
+            updated = sum(len(items_group) for _, items_group in groups)
         else:
             batch_count = len(groups)
             self.stdout.write(
@@ -719,16 +729,17 @@ class Command(BaseCommand):
                 f"({batch_count} batches)..."
             )
 
-            translation_items = []
+            updated = 0
             with handle_api_errors():
-                for texts_group, items_group in groups:
+                for batch_num, (texts_group, items_group) in enumerate(groups, 1):
                     translations = provider.translate(
                         texts_group, target_lang, context=context
                     )
 
+                    batch_items = []
                     pairs = zip(items_group, translations, strict=True)
                     for item, translation in pairs:
-                        translation_items.append(
+                        batch_items.append(
                             {
                                 "instance": item["instance"],
                                 "target_field": item["target_field"],
@@ -746,8 +757,10 @@ class Command(BaseCommand):
                             f"'{source_preview}' → '{translation_preview}'"
                         )
 
-        # Apply translations
-        updated = backend.apply_translations(translation_items, dry_run=dry_run)
+                    # Save after each batch so translations aren't lost if
+                    # a later batch fails
+                    updated += backend.apply_translations(batch_items, dry_run=dry_run)
+                    self.stdout.write(f"  💾 Saved batch {batch_num}/{batch_count}")
 
         self.stdout.write("\n" + "=" * 60)
         if dry_run:

--- a/tests/test_modeltranslation_integration.py
+++ b/tests/test_modeltranslation_integration.py
@@ -149,10 +149,8 @@ def test_translate_command_models_dry_run(settings, mock_env_api_key, mocker):
     output = out.getvalue()
     assert "Dry run" in output
 
-    # Verify dry_run=True was passed to apply_translations
-    mock_backend.apply_translations.assert_called_once()
-    call_kwargs = mock_backend.apply_translations.call_args[1]
-    assert call_kwargs["dry_run"] is True
+    # In dry-run mode, apply_translations should not be called
+    mock_backend.apply_translations.assert_not_called()
 
 
 def test_translate_command_models_parse_error(settings, mock_env_api_key, mocker):
@@ -260,3 +258,65 @@ def test_translate_command_models_authentication_error(
 
     with pytest.raises(CommandError, match="Authentication failed"):
         call_command("translate", target_lang="nl", models=[])
+
+
+def test_translate_command_models_saves_after_each_batch(
+    settings, mock_env_api_key, mocker
+):
+    """Test that completed batch translations are saved even if a later batch fails."""
+    from litellm.exceptions import BadRequestError
+
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    # Mock the backend
+    mock_backend_class = mocker.patch(
+        "translatebot_django.backends.modeltranslation.ModeltranslationBackend"
+    )
+    mock_backend = mocker.MagicMock()
+
+    # Create fake translatable items (enough for 2+ batches)
+    fake_items = []
+    for i in range(100):
+        fake_items.append(
+            {
+                "model": Article,
+                "instance": mocker.MagicMock(),
+                "field": "content",
+                "target_field": "content_nl",
+                "source_text": f"Long content {i} " * 100,
+            }
+        )
+
+    mock_backend.gather_translatable_content.return_value = fake_items
+    mock_backend.apply_translations.return_value = 1
+    mock_backend_class.return_value = mock_backend
+
+    # First call succeeds, second raises an error
+    call_count = {"n": 0}
+
+    def translate_side_effect(text, **_kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return [f"Translated {i}" for i in range(len(text))]
+        raise BadRequestError(
+            message="credit balance is too low",
+            model="gpt-4o-mini",
+            llm_provider="openai",
+        )
+
+    mocker.patch(
+        "translatebot_django.management.commands.translate.translate_text",
+        side_effect=translate_side_effect,
+    )
+
+    # Mock get_max_tokens to force batching
+    mocker.patch(
+        "translatebot_django.management.commands.translate.get_max_tokens",
+        return_value=1000,
+    )
+
+    with pytest.raises(CommandError, match="Insufficient API credits"):
+        call_command("translate", target_lang="nl", models=[])
+
+    # The first batch should have been saved before the second batch failed
+    assert mock_backend.apply_translations.call_count == 1


### PR DESCRIPTION
When translations are split into multiple batches and a later batch fails (e.g., API error, rate limit, credit exhaustion), translations from earlier successful batches were lost because saving only happened after all batches completed.

Now both model field and PO file translations are persisted to the database/disk after each successful batch, so completed work is never discarded.