### PR TITLE
fix: use email-shaped placeholders for DeepL Balkan languages

### DIFF
--- a/src/translatebot_django/providers/deepl.py
+++ b/src/translatebot_django/providers/deepl.py
@@ -36,6 +36,16 @@ _PLACEHOLDER_RE = re.compile(
 # a collision with literal <x> in source text is theoretically possible but
 # unlikely in practice.
 
+# Languages where the DeepL model doesn't reliably preserve <x> tags in
+# plain-text mode.  These were added to DeepL in late 2024/2025 and run on a
+# newer model that mangles inline HTML-like tags.  For these we replace
+# placeholders with email-shaped tokens (ph0@tb.x, ph1@tb.x, …) which every
+# model preserves because emails are never translated.
+# See: https://github.com/gettranslatebot/translatebot-django/issues/95
+_EMAIL_PLACEHOLDER_LANGS = frozenset({"SQ", "BS", "HR", "MK", "SR"})
+
+_EMAIL_PH_RE = re.compile(r"ph(\d+)@tb\.x")
+
 
 def _wrap_placeholders(text):
     """Wrap format placeholders in <x> tags so DeepL leaves them alone."""
@@ -45,6 +55,34 @@ def _wrap_placeholders(text):
 def _unwrap_placeholders(text):
     """Remove <x> tags that were wrapped around placeholders."""
     return text.replace("<x>", "").replace("</x>", "")
+
+
+def _replace_placeholders_with_emails(text):
+    """Replace format placeholders with email-shaped tokens.
+
+    Returns (replaced_text, list_of_originals) so they can be restored later.
+    """
+    originals = []
+
+    def _sub(m):
+        idx = len(originals)
+        originals.append(m.group())
+        return f"ph{idx}@tb.x"
+
+    replaced = _PLACEHOLDER_RE.sub(_sub, text)
+    return replaced, originals
+
+
+def _restore_email_placeholders(text, originals):
+    """Swap email-shaped tokens back to the original placeholders."""
+
+    def _sub(m):
+        idx = int(m.group(1))
+        if idx < len(originals):
+            return originals[idx]
+        return m.group()  # defensive: leave unknown tokens as-is
+
+    return _EMAIL_PH_RE.sub(_sub, text)
 
 
 def django_to_deepl_target(lang_code):
@@ -88,12 +126,21 @@ class DeepLProvider(TranslationProvider):
 
     def translate(self, texts, target_lang, context=None, comments=None):
         deepl_lang = django_to_deepl_target(target_lang)
+        use_email_ph = deepl_lang.split("-")[0] in _EMAIL_PLACEHOLDER_LANGS
 
-        wrapped = [_wrap_placeholders(t) for t in texts]
+        if use_email_ph:
+            prepared = []
+            originals_per_text = []
+            for t in texts:
+                replaced, originals = _replace_placeholders_with_emails(t)
+                prepared.append(replaced)
+                originals_per_text.append(originals)
+        else:
+            prepared = [_wrap_placeholders(t) for t in texts]
 
         try:
             results = self._translator.translate_text(
-                wrapped,
+                prepared,
                 target_lang=deepl_lang,
                 preserve_formatting=True,
             )
@@ -117,7 +164,13 @@ class DeepLProvider(TranslationProvider):
         except self._deepl.DeepLException as e:
             raise CommandError(f"DeepL API error: {e}") from e
 
-        translations = [_unwrap_placeholders(r.text) for r in results]
+        if use_email_ph:
+            translations = [
+                _restore_email_placeholders(r.text, orig)
+                for r, orig in zip(results, originals_per_text, strict=True)
+            ]
+        else:
+            translations = [_unwrap_placeholders(r.text) for r in results]
 
         # DeepL sometimes adds a trailing dot to translations even when the
         # source string does not end with one.  Strip it in that case.

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -416,12 +416,12 @@ def test_deepl_translate_protects_placeholders():
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
-    mock_result.text = f"Dostupno u {_w('%(country)s')} od {_w('%(start_date)s')}"
+    mock_result.text = f"Verfügbar in {_w('%(country)s')} ab {_w('%(start_date)s')}"
 
     provider._translator.translate_text = MagicMock(return_value=[mock_result])
 
-    result = provider.translate(["Available in %(country)s from %(start_date)s"], "hr")
-    assert result == ["Dostupno u %(country)s od %(start_date)s"]
+    result = provider.translate(["Available in %(country)s from %(start_date)s"], "de")
+    assert result == ["Verfügbar in %(country)s ab %(start_date)s"]
 
     # Verify wrapped text was sent to the API
     sent_texts = provider._translator.translate_text.call_args[0][0]
@@ -474,6 +474,133 @@ def test_deepl_translate_no_placeholders_unchanged():
 
     sent_texts = provider._translator.translate_text.call_args[0][0]
     assert sent_texts == ["Hello World"]
+
+
+# --- DeepL email placeholder tests (affected languages) ---
+
+
+@pytest.mark.parametrize(
+    "text, expected_replaced, expected_originals",
+    [
+        ("%(country)s", "ph0@tb.x", ["%(country)s"]),
+        (
+            "Available in %(country)s from %(start_date)s",
+            "Available in ph0@tb.x from ph1@tb.x",
+            ["%(country)s", "%(start_date)s"],
+        ),
+        (
+            "{name} has {count} items",
+            "ph0@tb.x has ph1@tb.x items",
+            ["{name}", "{count}"],
+        ),
+        ("%s items", "ph0@tb.x items", ["%s"]),
+        ("No placeholders", "No placeholders", []),
+        ("", "", []),
+    ],
+)
+def test_replace_placeholders_with_emails(text, expected_replaced, expected_originals):
+    """_replace_placeholders_with_emails swaps placeholders for email tokens."""
+    from translatebot_django.providers.deepl import _replace_placeholders_with_emails
+
+    replaced, originals = _replace_placeholders_with_emails(text)
+    assert replaced == expected_replaced
+    assert originals == expected_originals
+
+
+@pytest.mark.parametrize(
+    "text, originals, expected",
+    [
+        ("ph0@tb.x", ["%(country)s"], "%(country)s"),
+        (
+            "Dostupno u ph0@tb.x od ph1@tb.x",
+            ["%(country)s", "%(start_date)s"],
+            "Dostupno u %(country)s od %(start_date)s",
+        ),
+        ("no tokens here", [], "no tokens here"),
+        ("", [], ""),
+        # Out-of-range index left as-is
+        ("ph5@tb.x", ["%(name)s"], "ph5@tb.x"),
+    ],
+)
+def test_restore_email_placeholders(text, originals, expected):
+    """_restore_email_placeholders swaps email tokens back to originals."""
+    from translatebot_django.providers.deepl import _restore_email_placeholders
+
+    assert _restore_email_placeholders(text, originals) == expected
+
+
+@pytest.mark.parametrize("lang", ["hr", "sr", "bs", "sq", "mk"])
+def test_deepl_translate_affected_lang_uses_email_placeholders(lang):
+    """Affected languages use email-shaped placeholders instead of <x> tags."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    mock_result = MagicMock()
+    mock_result.text = "Dostupno u ph0@tb.x od ph1@tb.x"
+
+    provider._translator.translate_text = MagicMock(return_value=[mock_result])
+
+    result = provider.translate(["Available in %(country)s from %(start_date)s"], lang)
+    assert result == ["Dostupno u %(country)s od %(start_date)s"]
+
+    # Verify email tokens were sent, not <x> tags
+    sent_texts = provider._translator.translate_text.call_args[0][0]
+    assert sent_texts == ["Available in ph0@tb.x from ph1@tb.x"]
+
+
+@pytest.mark.parametrize("lang", ["de", "fr", "it", "nl", "ja"])
+def test_deepl_translate_normal_lang_uses_x_tags(lang):
+    """Non-affected languages still use the <x> tag approach."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    mock_result = MagicMock()
+    mock_result.text = f"Translated {_w('%(name)s')}"
+
+    provider._translator.translate_text = MagicMock(return_value=[mock_result])
+
+    result = provider.translate(["Hello %(name)s"], lang)
+    assert result == ["Translated %(name)s"]
+
+    sent_texts = provider._translator.translate_text.call_args[0][0]
+    assert sent_texts == [f"Hello {_w('%(name)s')}"]
+
+
+def test_deepl_translate_affected_lang_no_placeholders():
+    """Affected languages with no placeholders pass through normally."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    mock_result = MagicMock()
+    mock_result.text = "Zdravo svijete"
+
+    provider._translator.translate_text = MagicMock(return_value=[mock_result])
+
+    result = provider.translate(["Hello World"], "hr")
+    assert result == ["Zdravo svijete"]
+
+    sent_texts = provider._translator.translate_text.call_args[0][0]
+    assert sent_texts == ["Hello World"]
+
+
+def test_deepl_translate_affected_lang_preserves_html():
+    """Affected languages preserve HTML tags alongside email placeholders."""
+    from translatebot_django.providers.deepl import DeepLProvider
+
+    provider = DeepLProvider(api_key="test-key")
+
+    source = 'Click <a href="/shop">%(name)s</a> & visit <b>us</b>'
+
+    mock_result = MagicMock()
+    mock_result.text = 'Kliknite <a href="/shop">ph0@tb.x</a> & posjetite <b>nas</b>'
+
+    provider._translator.translate_text = MagicMock(return_value=[mock_result])
+
+    result = provider.translate([source], "hr")
+    assert result == ['Kliknite <a href="/shop">%(name)s</a> & posjetite <b>nas</b>']
 
 
 # --- DeepL import guard test ---


### PR DESCRIPTION
## Summary

- DeepL newer model serving Albanian (SQ), Bosnian (BS), Croatian (HR), Macedonian (MK), and Serbian (SR) mangles `<x>` placeholder tags in plain-text mode
- For these 5 languages, format placeholders are now replaced with email-shaped tokens (`ph0@tb.x`, `ph1@tb.x`, ...) that translation models universally preserve -- DeepL itself uses this pattern internally (`xml-ph-0000@deepl.internal`)
- Non-affected languages continue using the existing `<x>` tag approach unchanged

## Context

Reported in #95 -- the `<x>` wrapping approach works for most languages but fails for Albanian, Bosnian, Croatian, Macedonian, and Serbian. These languages were added to DeepL in late 2024/2025 and run on a newer model that does not reliably preserve inline HTML-like tags in plain-text mode (no `tag_handling` set).

Research across DeepL issue trackers ([deepl-api-issues#25](https://github.com/DeepLcom/deepl-api-issues/issues/25), [deepl-python#93](https://github.com/DeepLcom/deepl-python/issues/93), [deepl-python#77](https://github.com/DeepLcom/deepl-python/issues/77)) confirmed this is a known model-level issue with no fix planned by DeepL.

## Test plan

- [x] Unit tests for `_replace_placeholders_with_emails` and `_restore_email_placeholders`
- [x] Integration tests verifying email placeholder path for all 5 affected languages
- [x] Integration tests verifying `<x>` tag path unchanged for non-affected languages (de, fr, it, nl, ja)
- [x] Tests for edge cases: no placeholders, HTML preservation, trailing dot stripping
- [x] Full test suite passes (253 tests)

Fixes #95