### PR TITLE
Release 0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.4] - 2026-03-07
+
+### Fixed
+
+- Fixed DeepL placeholder protection failing for Albanian, Bosnian, Croatian, Macedonian, and Serbian. These languages run on a newer DeepL model that mangles `<x>` wrapper tags. Placeholders are now replaced with email-shaped tokens (`ph0@tb.x`, `ph1@tb.x`, …) that all models preserve.
+
 ## [0.9.3] - 2026-03-07
 
 ### Fixed
@@ -322,6 +328,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Django 4.2, 5.0, 5.1, 5.2, and 6.0
 - Support for Python 3.9 through 3.14
 
+[0.9.4]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.0...v0.9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "0.9.3"
+version = "0.9.4"
 description = "Automate Django .po file translation with AI. Repeatable, consistent, and pennies per language."
 authors = [
   { name = "Bjorn the Builder" },

--- a/uv.lock
+++ b/uv.lock
@@ -2081,7 +2081,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

- Bump version to 0.9.4
- Update CHANGELOG.md

### Changes in this release

- Fixed DeepL placeholder protection failing for Albanian, Bosnian, Croatian, Macedonian, and Serbian. These languages run on a newer DeepL model that mangles `<x>` wrapper tags. Placeholders are now replaced with email-shaped tokens that all models preserve.
