### PR TITLE
fix: detect DeepL newer-model languages via supports_formality API

### DIFF
--- a/src/translatebot_django/providers/deepl.py
+++ b/src/translatebot_django/providers/deepl.py
@@ -203,9 +203,7 @@ class DeepLProvider(TranslationProvider):
 
         if use_email_ph:
             translations = []
-            for r, orig, src in zip(
-                results, originals_per_text, texts, strict=True
-            ):
+            for r, orig, src in zip(results, originals_per_text, texts, strict=True):
                 translated = _restore_email_placeholders(r.text, orig)
                 # Only unescape entities that DeepL added (tag_handling="html"
                 # encodes plain < > & as entities).  If the source already

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -725,18 +725,14 @@ def test_deepl_translate_affected_lang_preserves_source_entities():
 
     mock_result = MagicMock()
     # Source already has &lt; &gt; entities — DeepL preserves them as-is
-    mock_result.text = (
-        "Koristite operatore &lt; ili &gt; (npr. &lt;100 ili &gt;50)"
-    )
+    mock_result.text = "Koristite operatore &lt; ili &gt; (npr. &lt;100 ili &gt;50)"
 
     provider._translator.translate_text = MagicMock(return_value=[mock_result])
 
     # Source contains HTML entities — they should be preserved in output
     source = "Use &lt; or &gt; operators (e.g. &lt;100 or &gt;50)"
     result = provider.translate([source], "hr")
-    assert result == [
-        "Koristite operatore &lt; ili &gt; (npr. &lt;100 ili &gt;50)"
-    ]
+    assert result == ["Koristite operatore &lt; ili &gt; (npr. &lt;100 ili &gt;50)"]
 
 
 def test_deepl_translate_affected_lang_mixed_batch_entities():


### PR DESCRIPTION
Replace hardcoded `_EMAIL_PLACEHOLDER_LANGS` set with dynamic detection using get_target_languages(). Languages without formality support run on newer DeepL models that mangle <x> tags. For these, use email-shaped placeholder tokens with `tag_handling="html"` to also preserve real HTML in modeltranslation fields, and `html.unescape()` to undo entity encoding.

Fixes #95, fixes #107 for Balkan languages.