### PR TITLE
Release 0.9.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.6] - 2026-03-16
+
+### Fixed
+
+- Fixed DeepL placeholder strategy inconsistency across languages. All languages now use email-shaped placeholders (`ph0@tb.x`, …) and `tag_handling="html"`, replacing the previous split between newer-model and legacy-model strategies.
+
+### Changed
+
+- Updated litellm from 1.82.1 to 1.82.2
+- Updated ruff from 0.15.5 to 0.15.6
+
 ## [0.9.5] - 2026-03-13
 
 ### Fixed
@@ -339,6 +350,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Django 4.2, 5.0, 5.1, 5.2, and 6.0
 - Support for Python 3.9 through 3.14
 
+[0.9.6]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.5...v0.9.6
 [0.9.5]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.4...v0.9.5
 [0.9.4]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.3...v0.9.4
 [0.9.3]: https://github.com/gettranslatebot/translatebot-django/compare/v0.9.2...v0.9.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "0.9.5"
+version = "0.9.6"
 description = "Automate Django .po file translation with AI. Repeatable, consistent, and pennies per language."
 authors = [
   { name = "Bjorn the Builder" },

--- a/uv.lock
+++ b/uv.lock
@@ -2081,7 +2081,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "0.9.5"
+version = "0.9.6"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary
- Bump version to 0.9.6
- Update CHANGELOG with release notes

## Changes since 0.9.5
- **Fixed**: DeepL placeholder strategy inconsistency — all languages now use email-shaped placeholders and `tag_handling="html"`
- **Changed**: Updated litellm 1.82.1 → 1.82.2, ruff 0.15.5 → 0.15.6