### PR TITLE
fix: disambiguate language code in translation preamble (#136)

### DIFF
--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -152,7 +152,8 @@ def build_system_prompt(context=None):
 
 def create_preamble(target_lang, count):
     return (
-        f"Translate the following {count} strings to {target_lang}. "
+        f"Translate the following {count} strings to the language"
+        f" with language code '{target_lang}'. "
         f"Return only a valid JSON array with exactly {count} translated strings:\n"
     )
 


### PR DESCRIPTION
Short language codes like "it" (Italian) can be confused with English pronouns by simpler LLM models. Wrap the target language in an explicit "language code '...'" label so the intent is unambiguous.