### PR TITLE
fix: drop unsupported LLM params for model compatibility (#135)

### DIFF
--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -221,7 +221,9 @@ def translate_text(text, target_lang, model, api_key, context=None, comments=Non
                             + json.dumps(input_payload, ensure_ascii=False),
                         },
                     ],
-                    temperature=0.2,  # Low randomness for consistency
+                    temperature=0.2,
+                    reasoning_effort="low",
+                    drop_params=True,
                     api_key=api_key,
                 )
             break  # Success, exit retry loop


### PR DESCRIPTION
Pass drop_params=True to completion() so unsupported parameters (e.g. temperature for gpt-5 models) are silently dropped instead of raising UnsupportedParamsError. Add reasoning_effort="low" for reasoning models.