### PR TITLE
feat: add public Python API for programmatic translations (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ TranslateBot is a dedicated tool that sits between "do it by hand" and "pay for 
 
 ## Installation
 
-TranslateBot is a development tool, so we recommend installing it as a dev dependency:
+For PO file translation, TranslateBot is a development tool — install it as a dev dependency:
 
 ```bash
 uv add --dev translatebot-django
+```
+
+For model translation at runtime, install it as a regular dependency instead (see [Python API docs](https://translatebot.dev/docs/usage/python-api/)):
+
+```bash
+uv add translatebot-django
 ```
 
 ## Quick Start

--- a/src/translatebot_django/__init__.py
+++ b/src/translatebot_django/__init__.py
@@ -1,1 +1,5 @@
+from translatebot_django.api import translate
+
 default_app_config = "translatebot_django.apps.TranslateBotDjangoConfig"
+
+__all__ = ["translate"]

--- a/src/translatebot_django/api.py
+++ b/src/translatebot_django/api.py
@@ -1,0 +1,101 @@
+from django.core.management import call_command
+
+
+def translate(
+    *,
+    target_langs=None,
+    dry_run=False,
+    overwrite=False,
+    apps=None,
+    models=None,
+):
+    """Translate PO files and/or model fields programmatically.
+
+    This is the public Python API for TranslateBot. It provides the same
+    functionality as the ``translate`` management command but can be called
+    directly from Python code — for example, from a Celery task, a custom
+    management command, or a Django view.
+
+    Args:
+        target_langs: Language code or list of language codes to translate to
+            (e.g. ``"nl"`` or ``["nl", "de"]``). When omitted, translates to
+            all languages defined in ``settings.LANGUAGES``, excluding the
+            source language (``settings.LANGUAGE_CODE``).
+        dry_run: If ``True``, preview what would be translated without saving.
+        overwrite: If ``True``, re-translate entries that already have
+            translations.
+        apps: App label or list of app labels to restrict PO file translation
+            to (e.g. ``"blog"`` or ``["blog", "shop"]``). Cannot be combined
+            with *models*.
+        models: Controls model field translation via django-modeltranslation.
+
+            - ``None`` (default): translate PO files only.
+            - ``True`` or ``[]``: translate all registered model fields.
+            - A list of model names (e.g. ``["Article", "Product"]``):
+              translate only those models.
+
+    Raises:
+        ValueError: If *apps* and *models* are both provided, or if *models*
+            is not ``True``, a list, or ``None``.
+        django.core.management.base.CommandError: On configuration or
+            translation errors (missing API key, unknown language, etc.).
+
+    Examples::
+
+        from translatebot_django import translate
+
+        # Translate PO files to all configured languages
+        translate()
+
+        # Translate to specific languages
+        translate(target_langs=["nl", "de"])
+
+        # Translate model fields
+        translate(models=True)
+
+        # Translate specific models for one language
+        translate(target_langs="fr", models=["Article", "Product"])
+
+        # Preview changes
+        translate(dry_run=True)
+
+        # Use in a Celery task
+        from celery import shared_task
+
+        @shared_task
+        def translate_nightly():
+            translate()
+    """
+    if apps is not None and models is not None:
+        raise ValueError(
+            "apps and models cannot be used together. "
+            "The apps parameter only filters PO file translation."
+        )
+
+    kwargs = {
+        "dry_run": dry_run,
+        "overwrite": overwrite,
+    }
+
+    if target_langs is not None:
+        if isinstance(target_langs, str):
+            target_langs = [target_langs]
+        kwargs["target_lang"] = list(target_langs)
+
+    if apps is not None:
+        if isinstance(apps, str):
+            apps = [apps]
+        kwargs["apps"] = list(apps)
+
+    if models is not None:
+        if models is True:
+            kwargs["models"] = []
+        elif isinstance(models, list):
+            kwargs["models"] = models
+        else:
+            raise ValueError(
+                "models must be True, a list of model names, or None. "
+                f"Got {type(models).__name__}."
+            )
+
+    call_command("translate", **kwargs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,133 @@
+"""
+Tests for the public Python API (translatebot_django.api.translate).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from translatebot_django import translate
+from translatebot_django.api import translate as translate_from_api
+
+
+def test_translate_is_importable_from_package():
+    """translate() is importable from the top-level package."""
+    assert translate is translate_from_api
+
+
+def test_translate_delegates_to_management_command(sample_po_file, mock_env_api_key):
+    """translate() calls the translate management command under the hood."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl"],
+        )
+
+
+def test_translate_no_args_omits_target_lang(sample_po_file, mock_env_api_key):
+    """When target_langs is omitted, target_lang kwarg is not passed."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+        )
+
+
+def test_translate_multiple_langs(sample_po_file, mock_env_api_key):
+    """A list of languages is forwarded correctly."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs=["nl", "de"], dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl", "de"],
+        )
+
+
+def test_translate_apps_string(sample_po_file, mock_env_api_key):
+    """A single app label string is normalized to a list."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", apps="blog", dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl"],
+            apps=["blog"],
+        )
+
+
+def test_translate_apps_list(sample_po_file, mock_env_api_key):
+    """A list of app labels is forwarded correctly."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", apps=["blog", "shop"], dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl"],
+            apps=["blog", "shop"],
+        )
+
+
+def test_translate_models_true(sample_po_file, mock_env_api_key):
+    """models=True translates all registered models (empty list)."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", models=True, dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl"],
+            models=[],
+        )
+
+
+def test_translate_models_list(sample_po_file, mock_env_api_key):
+    """A list of model names is forwarded correctly."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", models=["Article"], dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=False,
+            target_lang=["nl"],
+            models=["Article"],
+        )
+
+
+def test_translate_models_invalid_type():
+    """An invalid models type raises ValueError."""
+    with pytest.raises(ValueError, match="models must be True"):
+        translate(models="Article")
+
+
+def test_translate_apps_and_models_mutually_exclusive():
+    """Passing both apps and models raises ValueError."""
+    with pytest.raises(ValueError, match="apps and models cannot be used together"):
+        translate(apps="blog", models=True)
+
+
+def test_translate_overwrite(sample_po_file, mock_env_api_key):
+    """The overwrite flag is forwarded correctly."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", overwrite=True, dry_run=True)
+        mock_call.assert_called_once_with(
+            "translate",
+            dry_run=True,
+            overwrite=True,
+            target_lang=["nl"],
+        )
+
+
+def test_translate_end_to_end_dry_run(
+    sample_po_file, mock_env_api_key, mock_model_config
+):
+    """End-to-end: translate() in dry-run mode completes without error."""
+    translate(target_langs="nl", dry_run=True)


### PR DESCRIPTION
Expose `translate()` as a callable function so users can trigger translations from Celery tasks, scripts, or any Python code without shelling out to the management command.

Also update README to clarify that modeltranslation users may need TranslateBot as a runtime (not just dev) dependency.