### PR TITLE
feat: return TranslateResult with statistics from translate()

### DIFF
--- a/src/translatebot_django/__init__.py
+++ b/src/translatebot_django/__init__.py
@@ -1,5 +1,5 @@
-from translatebot_django.api import translate
+from translatebot_django.api import TranslateResult, translate
 
 default_app_config = "translatebot_django.apps.TranslateBotDjangoConfig"
 
-__all__ = ["translate"]
+__all__ = ["TranslateResult", "translate"]

--- a/src/translatebot_django/api.py
+++ b/src/translatebot_django/api.py
@@ -1,4 +1,35 @@
+import dataclasses
+
 from django.core.management import call_command
+
+from translatebot_django.management.commands.translate import (
+    Command as TranslateCommand,
+)
+
+
+@dataclasses.dataclass
+class TranslateResult:
+    """Statistics returned by :func:`translate`.
+
+    Attributes:
+        strings_found: Number of translatable strings found in PO files.
+        strings_translated: Number of PO strings that were translated
+            (or would be translated in dry-run mode).
+        po_files: Number of PO files processed.
+        model_fields_found: Number of translatable model fields found.
+        model_fields_translated: Number of model fields that were translated
+            (or would be translated in dry-run mode).
+        target_langs: Language codes that were translated to.
+        dry_run: Whether the translation was a dry run.
+    """
+
+    strings_found: int = 0
+    strings_translated: int = 0
+    po_files: int = 0
+    model_fields_found: int = 0
+    model_fields_translated: int = 0
+    target_langs: list[str] = dataclasses.field(default_factory=list)
+    dry_run: bool = False
 
 
 def translate(
@@ -34,6 +65,11 @@ def translate(
             - A list of model names (e.g. ``["Article", "Product"]``):
               translate only those models.
 
+    Returns:
+        TranslateResult: Statistics about what was translated, including
+        counts of strings found, translated, PO files processed, and
+        model fields handled.
+
     Raises:
         ValueError: If *apps* and *models* are both provided, or if *models*
             is not ``True``, a list, or ``None``.
@@ -45,19 +81,22 @@ def translate(
         from translatebot_django import translate
 
         # Translate PO files to all configured languages
-        translate()
+        result = translate()
+        print(f"Translated {result.strings_translated} strings")
 
         # Translate to specific languages
-        translate(target_langs=["nl", "de"])
+        result = translate(target_langs=["nl", "de"])
 
         # Translate model fields
-        translate(models=True)
+        result = translate(models=True)
+        print(f"Updated {result.model_fields_translated} model fields")
 
         # Translate specific models for one language
         translate(target_langs="fr", models=["Article", "Product"])
 
         # Preview changes
-        translate(dry_run=True)
+        result = translate(dry_run=True)
+        print(f"Would translate {result.strings_found} strings")
 
         # Use in a Celery task
         from celery import shared_task
@@ -98,4 +137,15 @@ def translate(
                 f"Got {type(models).__name__}."
             )
 
-    call_command("translate", **kwargs)
+    cmd = TranslateCommand()
+    call_command(cmd, **kwargs)
+    stats = getattr(cmd, "_translate_stats", {})
+    return TranslateResult(
+        strings_found=stats.get("strings_found", 0),
+        strings_translated=stats.get("strings_translated", 0),
+        po_files=stats.get("po_files", 0),
+        model_fields_found=stats.get("model_fields_found", 0),
+        model_fields_translated=stats.get("model_fields_translated", 0),
+        target_langs=stats.get("target_langs", []),
+        dry_run=dry_run,
+    )

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -509,6 +509,13 @@ class Command(BaseCommand):
                     )
                 )
 
+        # Aggregate statistics across all languages
+        total_strings_found = 0
+        total_strings_translated = 0
+        total_po_files = 0
+        total_model_fields_found = 0
+        total_model_fields_translated = 0
+
         # Process each target language
         for lang in target_langs:
             if len(target_langs) > 1:
@@ -518,7 +525,7 @@ class Command(BaseCommand):
 
             # Handle .po file translation (existing logic)
             if translate_po:
-                self._translate_po_files(
+                po_stats = self._translate_po_files(
                     lang,
                     dry_run,
                     overwrite,
@@ -526,10 +533,13 @@ class Command(BaseCommand):
                     context,
                     app_labels=app_labels,
                 )
+                total_strings_found += po_stats["strings_found"]
+                total_strings_translated += po_stats["strings_translated"]
+                total_po_files += po_stats["po_files"]
 
             # Handle model field translation (NEW)
             if translate_models:
-                self._translate_model_fields(
+                model_stats = self._translate_model_fields(
                     target_lang=lang,
                     dry_run=dry_run,
                     overwrite=overwrite,
@@ -537,6 +547,8 @@ class Command(BaseCommand):
                     model_names=models_arg,
                     context=context,
                 )
+                total_model_fields_found += model_stats["model_fields_found"]
+                total_model_fields_translated += model_stats["model_fields_translated"]
 
         if len(target_langs) > 1:
             self.stdout.write("\n" + "=" * 60)
@@ -547,6 +559,16 @@ class Command(BaseCommand):
                 )
             )
             self.stdout.write("=" * 60)
+
+        # Read by api.translate() to build TranslateResult — keep in sync.
+        self._translate_stats = {
+            "strings_found": total_strings_found,
+            "strings_translated": total_strings_translated,
+            "po_files": total_po_files,
+            "model_fields_found": total_model_fields_found,
+            "model_fields_translated": total_model_fields_translated,
+            "target_langs": target_langs,
+        }
 
     @staticmethod
     def _save_po_translations(po_paths, msgid_to_translation, overwrite=False):
@@ -593,7 +615,12 @@ class Command(BaseCommand):
         context=None,
         app_labels=None,
     ):
-        """Translate .po files (existing logic refactored into method)."""
+        """Translate .po files (existing logic refactored into method).
+
+        Returns:
+            dict with ``strings_found``, ``strings_translated``, and
+            ``po_files`` counts.
+        """
         # Find all .po files for the target language
         po_paths = get_all_po_paths(target_lang, app_labels=app_labels)
 
@@ -681,7 +708,11 @@ class Command(BaseCommand):
                         f"✨ Language '{target_lang}': Already up to date"
                     )
                 )
-            return
+            return {
+                "strings_found": 0,
+                "strings_translated": 0,
+                "po_files": len(po_paths),
+            }
 
         self.stdout.write(f"ℹ️  Found {total_msgids} untranslated entries")
 
@@ -734,6 +765,12 @@ class Command(BaseCommand):
                 )
             )
 
+        return {
+            "strings_found": total_msgids,
+            "strings_translated": total_changed,
+            "po_files": len(po_paths),
+        }
+
     def _translate_model_fields(
         self,
         target_lang,
@@ -743,7 +780,12 @@ class Command(BaseCommand):
         model_names=None,
         context=None,
     ):
-        """Translate django-modeltranslation model fields."""
+        """Translate django-modeltranslation model fields.
+
+        Returns:
+            dict with ``model_fields_found`` and ``model_fields_translated``
+            counts.
+        """
         from translatebot_django.backends.modeltranslation import (
             ModeltranslationBackend,
         )
@@ -768,7 +810,7 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.SUCCESS("✨ No untranslated model fields found")
             )
-            return
+            return {"model_fields_found": 0, "model_fields_translated": 0}
 
         self.stdout.write(f"ℹ️  Found {len(items)} model fields to translate")
 
@@ -852,3 +894,8 @@ class Command(BaseCommand):
                     f"✨ Successfully translated {updated} model field(s)"
                 )
             )
+
+        return {
+            "model_fields_found": len(items),
+            "model_fields_translated": updated,
+        }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,8 +6,12 @@ from unittest.mock import patch
 
 import pytest
 
-from translatebot_django import translate
+from translatebot_django import TranslateResult, translate
+from translatebot_django.api import TranslateResult as TranslateResultFromApi
 from translatebot_django.api import translate as translate_from_api
+from translatebot_django.management.commands.translate import (
+    Command as TranslateCommand,
+)
 
 
 def test_translate_is_importable_from_package():
@@ -15,91 +19,101 @@ def test_translate_is_importable_from_package():
     assert translate is translate_from_api
 
 
+def test_translate_result_is_importable_from_package():
+    """TranslateResult is importable from the top-level package."""
+    assert TranslateResult is TranslateResultFromApi
+
+
+def _get_call_kwargs(mock_call):
+    """Extract the keyword arguments from a mocked call_command call."""
+    _, kwargs = mock_call.call_args
+    return kwargs
+
+
 def test_translate_delegates_to_management_command(sample_po_file, mock_env_api_key):
     """translate() calls the translate management command under the hood."""
     with patch("translatebot_django.api.call_command") as mock_call:
-        translate(target_langs="nl", dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl"],
-        )
+        result = translate(target_langs="nl", dry_run=True)
+        mock_call.assert_called_once()
+        # First positional arg is a TranslateCommand instance
+        cmd_arg = mock_call.call_args[0][0]
+        assert isinstance(cmd_arg, TranslateCommand)
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+        }
+        assert isinstance(result, TranslateResult)
+        assert result.dry_run is True
 
 
 def test_translate_no_args_omits_target_lang(sample_po_file, mock_env_api_key):
     """When target_langs is omitted, target_lang kwarg is not passed."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+        }
 
 
 def test_translate_multiple_langs(sample_po_file, mock_env_api_key):
     """A list of languages is forwarded correctly."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs=["nl", "de"], dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl", "de"],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl", "de"],
+        }
 
 
 def test_translate_apps_string(sample_po_file, mock_env_api_key):
     """A single app label string is normalized to a list."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs="nl", apps="blog", dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl"],
-            apps=["blog"],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+            "apps": ["blog"],
+        }
 
 
 def test_translate_apps_list(sample_po_file, mock_env_api_key):
     """A list of app labels is forwarded correctly."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs="nl", apps=["blog", "shop"], dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl"],
-            apps=["blog", "shop"],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+            "apps": ["blog", "shop"],
+        }
 
 
 def test_translate_models_true(sample_po_file, mock_env_api_key):
     """models=True translates all registered models (empty list)."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs="nl", models=True, dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl"],
-            models=[],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+            "models": [],
+        }
 
 
 def test_translate_models_list(sample_po_file, mock_env_api_key):
     """A list of model names is forwarded correctly."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs="nl", models=["Article"], dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=False,
-            target_lang=["nl"],
-            models=["Article"],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+            "models": ["Article"],
+        }
 
 
 def test_translate_models_invalid_type():
@@ -118,16 +132,58 @@ def test_translate_overwrite(sample_po_file, mock_env_api_key):
     """The overwrite flag is forwarded correctly."""
     with patch("translatebot_django.api.call_command") as mock_call:
         translate(target_langs="nl", overwrite=True, dry_run=True)
-        mock_call.assert_called_once_with(
-            "translate",
-            dry_run=True,
-            overwrite=True,
-            target_lang=["nl"],
-        )
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": True,
+            "target_lang": ["nl"],
+        }
+
+
+def test_translate_returns_translate_result(sample_po_file, mock_env_api_key):
+    """translate() always returns a TranslateResult, even when command sets no stats."""
+    with patch("translatebot_django.api.call_command"):
+        result = translate(target_langs="nl")
+        assert isinstance(result, TranslateResult)
+        assert result.strings_found == 0
+        assert result.strings_translated == 0
+        assert result.po_files == 0
+        assert result.model_fields_found == 0
+        assert result.model_fields_translated == 0
+        assert result.target_langs == []
+        assert result.dry_run is False
+
+
+def test_translate_returns_stats_from_command(sample_po_file, mock_env_api_key):
+    """translate() populates TranslateResult from command's _translate_stats."""
+    fake_stats = {
+        "strings_found": 10,
+        "strings_translated": 8,
+        "po_files": 3,
+        "model_fields_found": 0,
+        "model_fields_translated": 0,
+        "target_langs": ["nl"],
+    }
+
+    def set_stats_on_cmd(cmd, **kwargs):
+        cmd._translate_stats = fake_stats
+
+    with patch("translatebot_django.api.call_command", side_effect=set_stats_on_cmd):
+        result = translate(target_langs="nl")
+        assert result.strings_found == 10
+        assert result.strings_translated == 8
+        assert result.po_files == 3
+        assert result.target_langs == ["nl"]
+        assert result.dry_run is False
 
 
 def test_translate_end_to_end_dry_run(
     sample_po_file, mock_env_api_key, mock_model_config
 ):
-    """End-to-end: translate() in dry-run mode completes without error."""
-    translate(target_langs="nl", dry_run=True)
+    """End-to-end: translate() in dry-run mode returns stats."""
+    result = translate(target_langs="nl", dry_run=True)
+    assert isinstance(result, TranslateResult)
+    assert result.dry_run is True
+    assert result.target_langs == ["nl"]
+    assert result.strings_found >= 0
+    assert result.strings_translated >= 0
+    assert result.po_files >= 1

--- a/tests/test_modeltranslation_integration.py
+++ b/tests/test_modeltranslation_integration.py
@@ -320,3 +320,49 @@ def test_translate_command_models_saves_after_each_batch(
 
     # The first batch should have been saved before the second batch failed
     assert mock_backend.apply_translations.call_count == 1
+
+
+def test_translate_command_models_sets_stats(settings, mock_env_api_key, mocker):
+    """_translate_stats includes model field counts after --models translation."""
+    from translatebot_django.management.commands.translate import Command
+
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    mock_backend_class = mocker.patch(
+        "translatebot_django.backends.modeltranslation.ModeltranslationBackend"
+    )
+    mock_backend = mocker.MagicMock()
+
+    fake_items = [
+        {
+            "model": Article,
+            "instance": mocker.MagicMock(),
+            "field": "title",
+            "target_field": "title_nl",
+            "source_text": "Hello World",
+        },
+        {
+            "model": Article,
+            "instance": mocker.MagicMock(),
+            "field": "content",
+            "target_field": "content_nl",
+            "source_text": "Some content",
+        },
+    ]
+    mock_backend.gather_translatable_content.return_value = fake_items
+    mock_backend.apply_translations.return_value = 2
+    mock_backend_class.return_value = mock_backend
+
+    mocker.patch(
+        "translatebot_django.management.commands.translate.translate_text",
+        return_value=["Hallo Wereld", "Wat inhoud"],
+    )
+
+    cmd = Command(stdout=StringIO(), stderr=StringIO())
+    call_command(cmd, target_lang="nl", models=[])
+
+    stats = cmd._translate_stats
+    assert stats["model_fields_found"] == 2
+    assert stats["model_fields_translated"] == 2
+    assert stats["strings_found"] == 0
+    assert stats["target_langs"] == ["nl"]

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -3090,3 +3090,77 @@ def test_existing_translation_not_replaced_across_po_files(
     # djangojs.po must keep its original translation
     saved_js = polib.pofile(str(nl_dir / "djangojs.po"))
     assert saved_js[0].msgstr == "última"
+
+
+# ── _translate_stats contract tests ──────────────────────────────
+
+
+def test_handle_sets_translate_stats(
+    sample_po_file, mock_env_api_key, mock_completion, mock_model_config
+):
+    """handle() populates _translate_stats with correct PO file stats."""
+    mock_completion()
+
+    cmd = Command(stdout=StringIO(), stderr=StringIO())
+    call_command(cmd, target_lang="nl")
+
+    stats = cmd._translate_stats
+    assert stats["strings_found"] == 2  # sample_po_file has 2 untranslated
+    assert stats["strings_translated"] == 2
+    assert stats["po_files"] == 1
+    assert stats["model_fields_found"] == 0
+    assert stats["model_fields_translated"] == 0
+    assert stats["target_langs"] == ["nl"]
+
+
+def test_handle_sets_translate_stats_nothing_to_translate(
+    sample_po_file, mock_env_api_key, mock_model_config
+):
+    """_translate_stats reports zero strings when everything is up to date."""
+    # Translate first so everything is up to date
+    # (dry_run leaves entries empty, so use a pre-translated file instead)
+    import polib as _polib
+
+    po = _polib.pofile(str(sample_po_file))
+    for entry in po:
+        if not entry.msgstr:
+            entry.msgstr = "vertaald"
+    po.save(str(sample_po_file))
+
+    cmd = Command(stdout=StringIO(), stderr=StringIO())
+    call_command(cmd, target_lang="nl")
+
+    stats = cmd._translate_stats
+    assert stats["strings_found"] == 0
+    assert stats["strings_translated"] == 0
+    assert stats["po_files"] == 1
+
+
+def test_handle_stats_accumulate_across_languages(
+    tmp_path, settings, mocker, mock_env_api_key, mock_model_config, mock_completion
+):
+    """Stats are summed across multiple target languages."""
+    mock_completion()
+
+    # Create PO files for two languages, each with 1 untranslated entry
+    for lang in ("nl", "de"):
+        lang_dir = tmp_path / "locale" / lang / "LC_MESSAGES"
+        lang_dir.mkdir(parents=True)
+        po = polib.POFile()
+        po.metadata = {"Content-Type": "text/plain; charset=utf-8"}
+        po.append(polib.POEntry(msgid="Hello", msgstr=""))
+        po.save(str(lang_dir / "django.po"))
+
+    settings.LOCALE_PATHS = [str(tmp_path / "locale")]
+    mocker.patch("django.apps.apps.get_app_configs", return_value=[])
+
+    cmd = Command(stdout=StringIO(), stderr=StringIO())
+    call_command(cmd, target_lang=["nl", "de"])
+
+    stats = cmd._translate_stats
+    # 1 string per language × 2 languages = 2 total
+    assert stats["strings_found"] == 2
+    assert stats["strings_translated"] == 2
+    # 1 PO file per language × 2 languages = 2 total
+    assert stats["po_files"] == 2
+    assert stats["target_langs"] == ["nl", "de"]


### PR DESCRIPTION
The translate() Python API now returns a TranslateResult dataclass with useful statistics (strings_found, strings_translated, po_files, model_fields_found, model_fields_translated, target_langs, dry_run) instead of None, enabling callers to report on what was translated.