### PR TITLE
feat: support passing LLM model at runtime via translate() and --llm-…

### DIFF
--- a/src/translatebot_django/api.py
+++ b/src/translatebot_django/api.py
@@ -39,6 +39,7 @@ def translate(
     overwrite=False,
     apps=None,
     models=None,
+    model=None,
 ):
     """Translate PO files and/or model fields programmatically.
 
@@ -58,6 +59,11 @@ def translate(
         apps: App label or list of app labels to restrict PO file translation
             to (e.g. ``"blog"`` or ``["blog", "shop"]``). Cannot be combined
             with *models*.
+        model: LLM model name to use for this call, overriding
+            ``settings.TRANSLATEBOT_MODEL`` (e.g. ``"gpt-4o"`` or
+            ``"claude-3-5-sonnet-20241022"``). Has no effect when using the
+            DeepL provider — passing it with DeepL raises a
+            :exc:`~django.core.management.base.CommandError`.
         models: Controls model field translation via django-modeltranslation.
 
             - ``None`` (default): translate PO files only.
@@ -115,6 +121,9 @@ def translate(
         "dry_run": dry_run,
         "overwrite": overwrite,
     }
+
+    if model is not None:
+        kwargs["llm_model"] = model
 
     if target_langs is not None:
         if isinstance(target_langs, str):

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -412,6 +412,14 @@ class Command(BaseCommand):
             "Can be used multiple times to include multiple apps.",
         )
 
+        parser.add_argument(
+            "--llm-model",
+            default=None,
+            help="LLM model name to use for this run, overriding TRANSLATEBOT_MODEL "
+            "(e.g. 'gpt-4o', 'claude-3-5-sonnet-20241022'). "
+            "Not supported with the DeepL provider — raises an error if passed.",
+        )
+
         # Only add modeltranslation-related arguments if it's available
         if is_modeltranslation_available():
             parser.add_argument(
@@ -490,7 +498,8 @@ class Command(BaseCommand):
             )
 
         api_key = get_api_key()
-        provider = get_provider(api_key)
+        llm_model = options.get("llm_model")
+        provider = get_provider(api_key, model=llm_model)
 
         # Load translation context from TRANSLATING.md if available
         context = get_translation_context()

--- a/src/translatebot_django/providers/__init__.py
+++ b/src/translatebot_django/providers/__init__.py
@@ -45,13 +45,17 @@ class TranslationProvider(ABC):
         """Whether this provider can use TRANSLATING.md context."""
 
 
-def get_provider(api_key):
+def get_provider(api_key, model=None):
     """Create a translation provider based on Django settings.
 
     Reads TRANSLATEBOT_PROVIDER from settings. Defaults to 'litellm' if not set.
 
     Args:
         api_key: API key for the provider.
+        model: Optional LLM model name to use instead of the value from
+            ``settings.TRANSLATEBOT_MODEL``. Ignored for providers that do not
+            use a model (e.g. DeepL — passing a model for DeepL raises an
+            error).
 
     Returns:
         A TranslationProvider instance.
@@ -71,10 +75,15 @@ def get_provider(api_key):
         from translatebot_django.providers.litellm import LiteLLMProvider
         from translatebot_django.utils import get_model
 
-        model = get_model()
-        return LiteLLMProvider(model=model, api_key=api_key)
+        effective_model = model if model is not None else get_model()
+        return LiteLLMProvider(model=effective_model, api_key=api_key)
 
     if provider_name == "deepl":
+        if model is not None:
+            raise CommandError(
+                "The 'model' parameter is not supported for the DeepL provider. "
+                "DeepL does not use a language model."
+            )
         from translatebot_django.providers.deepl import DeepLProvider
 
         return DeepLProvider(api_key=api_key)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -176,6 +176,25 @@ def test_translate_returns_stats_from_command(sample_po_file, mock_env_api_key):
         assert result.dry_run is False
 
 
+def test_translate_model_forwarded(sample_po_file, mock_env_api_key):
+    """model= is forwarded to the command as llm_model."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", model="gpt-4o", dry_run=True)
+        assert _get_call_kwargs(mock_call) == {
+            "dry_run": True,
+            "overwrite": False,
+            "target_lang": ["nl"],
+            "llm_model": "gpt-4o",
+        }
+
+
+def test_translate_model_none_omitted(sample_po_file, mock_env_api_key):
+    """When model is not passed, llm_model is not included in kwargs."""
+    with patch("translatebot_django.api.call_command") as mock_call:
+        translate(target_langs="nl", dry_run=True)
+        assert "llm_model" not in _get_call_kwargs(mock_call)
+
+
 def test_translate_end_to_end_dry_run(
     sample_po_file, mock_env_api_key, mock_model_config
 ):

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,11 +1,22 @@
 """Tests for translation providers."""
 
+import builtins
 import sys
 from unittest.mock import MagicMock
 
+import deepl
 import pytest
 
 from django.core.management.base import CommandError
+
+from translatebot_django.providers import get_provider
+from translatebot_django.providers.deepl import (
+    DeepLProvider,
+    _replace_placeholders_with_emails,
+    _restore_email_placeholders,
+    django_to_deepl_target,
+)
+from translatebot_django.providers.litellm import LiteLLMProvider
 
 # --- Factory tests ---
 
@@ -17,9 +28,6 @@ def test_get_provider_default_is_litellm(settings, monkeypatch):
         delattr(settings, "TRANSLATEBOT_PROVIDER")
     settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
 
-    from translatebot_django.providers import get_provider
-    from translatebot_django.providers.litellm import LiteLLMProvider
-
     provider = get_provider("test-key")
     assert isinstance(provider, LiteLLMProvider)
 
@@ -29,9 +37,6 @@ def test_get_provider_explicit_litellm(settings):
     settings.TRANSLATEBOT_PROVIDER = "litellm"
     settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
 
-    from translatebot_django.providers import get_provider
-    from translatebot_django.providers.litellm import LiteLLMProvider
-
     provider = get_provider("test-key")
     assert isinstance(provider, LiteLLMProvider)
 
@@ -40,9 +45,6 @@ def test_get_provider_deepl(settings):
     """DeepL setting returns DeepLProvider."""
     settings.TRANSLATEBOT_PROVIDER = "deepl"
 
-    from translatebot_django.providers import get_provider
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = get_provider("test-key")
     assert isinstance(provider, DeepLProvider)
 
@@ -50,8 +52,6 @@ def test_get_provider_deepl(settings):
 def test_get_provider_unknown_raises_error(settings):
     """Unknown provider name raises CommandError."""
     settings.TRANSLATEBOT_PROVIDER = "unknown_provider"
-
-    from translatebot_django.providers import get_provider
 
     with pytest.raises(CommandError, match="Unknown translation provider"):
         get_provider("test-key")
@@ -62,9 +62,6 @@ def test_get_provider_model_override(settings):
     settings.TRANSLATEBOT_PROVIDER = "litellm"
     settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
 
-    from translatebot_django.providers import get_provider
-    from translatebot_django.providers.litellm import LiteLLMProvider
-
     provider = get_provider("test-key", model="claude-3-5-sonnet-20241022")
     assert isinstance(provider, LiteLLMProvider)
     assert provider.name == "claude-3-5-sonnet-20241022"
@@ -73,8 +70,6 @@ def test_get_provider_model_override(settings):
 def test_get_provider_model_deepl_raises_error(settings):
     """Passing model= when using DeepL raises CommandError."""
     settings.TRANSLATEBOT_PROVIDER = "deepl"
-
-    from translatebot_django.providers import get_provider
 
     with pytest.raises(CommandError, match="not supported for the DeepL provider"):
         get_provider("test-key", model="gpt-4o")
@@ -87,16 +82,12 @@ def test_litellm_provider_name(settings):
     """LiteLLMProvider.name returns the model name."""
     settings.TRANSLATEBOT_MODEL = "claude-3-sonnet"
 
-    from translatebot_django.providers.litellm import LiteLLMProvider
-
     provider = LiteLLMProvider(model="claude-3-sonnet", api_key="test-key")
     assert provider.name == "claude-3-sonnet"
 
 
 def test_litellm_provider_supports_context():
     """LiteLLMProvider supports TRANSLATING.md context."""
-    from translatebot_django.providers.litellm import LiteLLMProvider
-
     provider = LiteLLMProvider(model="gpt-4o-mini", api_key="test-key")
     assert provider.supports_context is True
 
@@ -106,16 +97,12 @@ def test_litellm_provider_supports_context():
 
 def test_deepl_provider_name():
     """DeepLProvider.name returns 'DeepL'."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     assert provider.name == "DeepL"
 
 
 def test_deepl_provider_supports_context():
     """DeepLProvider does not support TRANSLATING.md context."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     assert provider.supports_context is False
 
@@ -125,8 +112,6 @@ def test_deepl_provider_supports_context():
 
 def test_deepl_lang_mapping_simple():
     """Simple language codes are uppercased."""
-    from translatebot_django.providers.deepl import django_to_deepl_target
-
     assert django_to_deepl_target("de") == "DE"
     assert django_to_deepl_target("fr") == "FR"
     assert django_to_deepl_target("nl") == "NL"
@@ -135,22 +120,16 @@ def test_deepl_lang_mapping_simple():
 
 def test_deepl_lang_mapping_english_default():
     """'en' maps to 'EN-US' (DeepL requires a regional variant)."""
-    from translatebot_django.providers.deepl import django_to_deepl_target
-
     assert django_to_deepl_target("en") == "EN-US"
 
 
 def test_deepl_lang_mapping_portuguese_default():
     """'pt' maps to 'PT-BR' (DeepL requires a regional variant)."""
-    from translatebot_django.providers.deepl import django_to_deepl_target
-
     assert django_to_deepl_target("pt") == "PT-BR"
 
 
 def test_deepl_lang_mapping_regional_variant():
     """Regional variants like 'pt-br' are uppercased as-is."""
-    from translatebot_django.providers.deepl import django_to_deepl_target
-
     assert django_to_deepl_target("pt-br") == "PT-BR"
     assert django_to_deepl_target("zh-hans") == "ZH-HANS"
     assert django_to_deepl_target("en-gb") == "EN-GB"
@@ -161,8 +140,6 @@ def test_deepl_lang_mapping_regional_variant():
 
 def test_deepl_batch_under_limit():
     """Texts under both limits stay in a single batch."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     texts = ["Hello", "World", "Test"]
     batches = provider.batch(texts, "de")
@@ -171,8 +148,6 @@ def test_deepl_batch_under_limit():
 
 def test_deepl_batch_over_50_texts():
     """More than 50 texts are split into multiple batches."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     texts = [f"String {i}" for i in range(120)]
     batches = provider.batch(texts, "de")
@@ -189,8 +164,6 @@ def test_deepl_batch_over_50_texts():
 
 def test_deepl_batch_large_texts():
     """Texts exceeding 128KB are split by size."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     # Each text is ~10KB, so 128KB limit fits ~12 texts
     large_text = "A" * 10_000
@@ -206,8 +179,6 @@ def test_deepl_batch_large_texts():
 
 def test_deepl_batch_empty():
     """Empty input returns empty list."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     batches = provider.batch([], "de")
     assert batches == []
@@ -215,8 +186,6 @@ def test_deepl_batch_empty():
 
 def test_deepl_batch_single_oversized_text():
     """A single text larger than 128KB goes into its own batch."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     huge_text = "B" * (200 * 1024)  # 200KB
     texts = ["small", huge_text, "also small"]
@@ -234,8 +203,6 @@ def test_deepl_batch_single_oversized_text():
 
 def test_deepl_translate_basic(mocker):
     """DeepLProvider.translate returns translated texts."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result_1 = MagicMock()
@@ -260,8 +227,6 @@ def test_deepl_translate_basic(mocker):
 
 def test_deepl_translate_strips_trailing_dot():
     """Strip trailing dot added by DeepL when source has none."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     sources = ["Hello", "World", "Done.", ".", "OK", ""]
@@ -288,8 +253,6 @@ def test_deepl_translate_strips_trailing_dot():
 
 def test_deepl_translate_uses_mapped_lang(mocker):
     """DeepLProvider.translate converts language codes for the API."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -312,10 +275,6 @@ def test_deepl_translate_uses_mapped_lang(mocker):
 
 def test_deepl_translate_auth_error():
     """DeepL auth error raises CommandError."""
-    import deepl
-
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="bad-key")
     provider._translator.translate_text = MagicMock(
         side_effect=deepl.AuthorizationException("Invalid auth key")
@@ -327,10 +286,6 @@ def test_deepl_translate_auth_error():
 
 def test_deepl_translate_quota_error():
     """DeepL quota error raises CommandError."""
-    import deepl
-
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     provider._translator.translate_text = MagicMock(
         side_effect=deepl.QuotaExceededException("Quota exceeded")
@@ -342,10 +297,6 @@ def test_deepl_translate_quota_error():
 
 def test_deepl_translate_rate_limit_error():
     """DeepL rate limit error raises CommandError."""
-    import deepl
-
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     provider._translator.translate_text = MagicMock(
         side_effect=deepl.TooManyRequestsException("Too many requests")
@@ -357,10 +308,6 @@ def test_deepl_translate_rate_limit_error():
 
 def test_deepl_translate_generic_error():
     """Generic DeepL API error raises CommandError."""
-    import deepl
-
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
     provider._translator.translate_text = MagicMock(
         side_effect=deepl.DeepLException("Something went wrong")
@@ -375,8 +322,6 @@ def test_deepl_translate_generic_error():
 
 def test_deepl_translate_protects_placeholders():
     """Placeholders are replaced with email tokens before sending and restored after."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -398,8 +343,6 @@ def test_deepl_translate_protects_placeholders():
 
 def test_deepl_translate_preserves_html_with_placeholders():
     """HTML tags in source text are preserved through translation (regression test)."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     source = 'Click <a href="/shop">%(name)s</a> & visit <b>us</b>'
@@ -424,8 +367,6 @@ def test_deepl_translate_preserves_html_with_placeholders():
 
 def test_deepl_translate_no_placeholders_unchanged():
     """Texts without placeholders pass through normally."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -464,8 +405,6 @@ def test_deepl_translate_no_placeholders_unchanged():
 )
 def test_replace_placeholders_with_emails(text, expected_replaced, expected_originals):
     """_replace_placeholders_with_emails swaps placeholders for email tokens."""
-    from translatebot_django.providers.deepl import _replace_placeholders_with_emails
-
     replaced, originals = _replace_placeholders_with_emails(text)
     assert replaced == expected_replaced
     assert originals == expected_originals
@@ -488,8 +427,6 @@ def test_replace_placeholders_with_emails(text, expected_replaced, expected_orig
 )
 def test_restore_email_placeholders(text, originals, expected):
     """_restore_email_placeholders swaps email tokens back to originals."""
-    from translatebot_django.providers.deepl import _restore_email_placeholders
-
     assert _restore_email_placeholders(text, originals) == expected
 
 
@@ -498,8 +435,6 @@ def test_restore_email_placeholders(text, originals, expected):
 )
 def test_deepl_translate_uses_email_placeholders(lang):
     """All languages use email-shaped placeholders and tag_handling=html."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -521,8 +456,6 @@ def test_deepl_translate_uses_email_placeholders(lang):
 
 def test_deepl_translate_unescapes_html_entities():
     """html.unescape() decodes entities produced by tag_handling=html."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -537,8 +470,6 @@ def test_deepl_translate_unescapes_html_entities():
 
 def test_deepl_translate_preserves_source_entities():
     """Source text with HTML entities is NOT unescaped (entities are intentional)."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_result = MagicMock()
@@ -555,8 +486,6 @@ def test_deepl_translate_preserves_source_entities():
 
 def test_deepl_translate_mixed_batch_entities():
     """Batch with plain text and HTML content handles each correctly."""
-    from translatebot_django.providers.deepl import DeepLProvider
-
     provider = DeepLProvider(api_key="test-key")
 
     mock_r1 = MagicMock()
@@ -583,8 +512,6 @@ def test_deepl_import_guard_raises_error(monkeypatch):
     original = sys.modules.pop("deepl", None)
     # Also remove our provider module so it re-imports
     sys.modules.pop("translatebot_django.providers.deepl", None)
-
-    import builtins
 
     original_import = builtins.__import__
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -57,6 +57,29 @@ def test_get_provider_unknown_raises_error(settings):
         get_provider("test-key")
 
 
+def test_get_provider_model_override(settings):
+    """Passing model= to get_provider() uses it instead of TRANSLATEBOT_MODEL."""
+    settings.TRANSLATEBOT_PROVIDER = "litellm"
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    from translatebot_django.providers import get_provider
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    provider = get_provider("test-key", model="claude-3-5-sonnet-20241022")
+    assert isinstance(provider, LiteLLMProvider)
+    assert provider.name == "claude-3-5-sonnet-20241022"
+
+
+def test_get_provider_model_deepl_raises_error(settings):
+    """Passing model= when using DeepL raises CommandError."""
+    settings.TRANSLATEBOT_PROVIDER = "deepl"
+
+    from translatebot_django.providers import get_provider
+
+    with pytest.raises(CommandError, match="not supported for the DeepL provider"):
+        get_provider("test-key", model="gpt-4o")
+
+
 # --- LiteLLM provider property tests ---
 
 

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -3164,3 +3164,27 @@ def test_handle_stats_accumulate_across_languages(
     # 1 PO file per language × 2 languages = 2 total
     assert stats["po_files"] == 2
     assert stats["target_langs"] == ["nl", "de"]
+
+
+@pytest.mark.usefixtures("sample_po_file", "mock_env_api_key")
+def test_llm_model_flag_reaches_provider(settings, mocker):
+    """--llm-model / llm_model= overrides the model used to construct the provider."""
+    settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
+
+    from translatebot_django.providers.litellm import LiteLLMProvider
+
+    mock_provider = mocker.MagicMock(spec=LiteLLMProvider)
+    mock_provider.name = "gpt-4o"
+    mock_provider.supports_context = False
+    mock_provider.batch.return_value = []
+
+    mock_get_provider = mocker.patch(
+        "translatebot_django.management.commands.translate.get_provider",
+        return_value=mock_provider,
+    )
+
+    call_command("translate", target_lang="nl", dry_run=True, llm_model="gpt-4o")
+
+    mock_get_provider.assert_called_once()
+    _, kwargs = mock_get_provider.call_args
+    assert kwargs.get("model") == "gpt-4o"

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -15,6 +15,7 @@ from translatebot_django.management.commands.translate import (
     TranslationValidationError,
     translate_text,
 )
+from translatebot_django.providers.litellm import LiteLLMProvider
 from translatebot_django.utils import (
     combine_translation_contexts,
     get_all_po_paths,
@@ -3170,8 +3171,6 @@ def test_handle_stats_accumulate_across_languages(
 def test_llm_model_flag_reaches_provider(settings, mocker):
     """--llm-model / llm_model= overrides the model used to construct the provider."""
     settings.TRANSLATEBOT_MODEL = "gpt-4o-mini"
-
-    from translatebot_django.providers.litellm import LiteLLMProvider
 
     mock_provider = mocker.MagicMock(spec=LiteLLMProvider)
     mock_provider.name = "gpt-4o"


### PR DESCRIPTION
…model

Add a `model` parameter to the public `translate()` API and a `--llm-model` CLI flag to the translate management command. When provided, the given model name overrides `settings.TRANSLATEBOT_MODEL` for that call only, allowing per-call model selection without mutating Django settings. Passing the parameter with the DeepL provider raises a CommandError since DeepL has no model concept.