### PR TITLE
Release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-04-13
+
+### Added
+
+- Runtime LLM model override: pass `model="gpt-4o"` to `translate()` or `--llm-model gpt-4o` to the `translate` management command to override `settings.TRANSLATEBOT_MODEL` for a single call. Useful for A/B testing models or running higher-quality translations on specific languages without mutating Django settings.
+- Raises `CommandError` when the `model` parameter is passed together with the DeepL provider, since DeepL has no model concept.
+
 ## [1.2.0] - 2026-04-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "1.2.0"
+version = "1.3.0"
 description = "Translate Django .po files and model fields with AI. Repeatable, consistent, and pennies per language."
 authors = [
   { name = "Bjorn the Builder" },

--- a/uv.lock
+++ b/uv.lock
@@ -2174,7 +2174,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
## Summary

- Bump version to 1.3.0
- Update changelog with new runtime LLM model override feature

## Changes since v1.2.0

- **feat**: Support passing LLM model at runtime via `translate(model=...)` and `--llm-model` (PR #175)
- **refactor(tests)**: Move inline imports to module level in provider / command tests