### PR TITLE
chore: bump version to 1.3.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-05-24
+
+### Changed
+
+- Updated Django from 5.2.13 to 5.2.14
+- Updated litellm
+- Updated urllib3 from 2.6.3 to 2.7.0
+- Updated idna from 3.13 to 3.15
+- Updated python-dotenv from 1.0.1 to 1.2.2
+- Updated aiohttp from 3.13.3 to 3.13.4
+- Updated ruff
+- Refreshed `uv.lock` with latest compatible versions
+
 ## [1.3.1] - 2026-04-17
 
 ### Fixed
@@ -420,6 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for Django 4.2, 5.0, 5.1, 5.2, and 6.0
 - Support for Python 3.9 through 3.14
 
+[1.3.2]: https://github.com/gettranslatebot/translatebot-django/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/gettranslatebot/translatebot-django/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/gettranslatebot/translatebot-django/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/gettranslatebot/translatebot-django/compare/v1.1.1...v1.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "translatebot-django"
-version = "1.3.1"
+version = "1.3.2"
 description = "Translate Django .po files and model fields with AI. Repeatable, consistent, and pennies per language."
 authors = [
   { name = "Bjorn the Builder" },

--- a/uv.lock
+++ b/uv.lock
@@ -2210,7 +2210,7 @@ wheels = [
 
 [[package]]
 name = "translatebot-django"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
## Summary
- Bump version to 1.3.2
- Dependency-only patch release: Django 5.2.14, litellm, urllib3 2.7.0, idna 3.15, python-dotenv 1.2.2, aiohttp 3.13.4, ruff, and refreshed uv.lock
