### PR TITLE
fix: discover legacy rows and stop bulk_update clobbering translations

### DIFF
--- a/src/translatebot_django/backends/modeltranslation.py
+++ b/src/translatebot_django/backends/modeltranslation.py
@@ -18,6 +18,7 @@ class ModeltranslationBackend:
         """
         from modeltranslation import settings as mt_settings
         from modeltranslation.translator import translator
+        from modeltranslation.utils import build_localized_fieldname
 
         self.translator = translator
         self.target_lang = target_lang
@@ -27,6 +28,14 @@ class ModeltranslationBackend:
         # modeltranslation was installed (or written via update()/imports)
         # have their default-language content only in the original column.
         self.default_lang = mt_settings.DEFAULT_LANGUAGE
+        # Use modeltranslation's own (import-time) language list: these are
+        # the languages it actually created columns for. Reading Django
+        # settings live could diverge from that and reference columns that
+        # don't exist.
+        self.available_langs = list(mt_settings.AVAILABLE_LANGUAGES)
+        # Maps e.g. ('title', 'en-gb') -> 'title_en_gb'; a raw f-string
+        # would produce invalid lookups for hyphenated language codes.
+        self._localized_fieldname = build_localized_fieldname
 
     def get_all_registered_models(self):
         """
@@ -60,7 +69,7 @@ class ModeltranslationBackend:
         Returns:
             str: Target language field name (e.g., 'title_nl')
         """
-        return f"{field_name}_{self.target_lang}"
+        return self._localized_fieldname(field_name, self.target_lang)
 
     def parse_model_names(self, model_names):
         """
@@ -122,6 +131,12 @@ class ModeltranslationBackend:
         """
         Gather all model field content that needs translation.
 
+        The default-language source is resolved the way modeltranslation's
+        ``update_translation_fields`` command would: when the
+        ``<field>_<default_lang>`` column is empty, the original column is
+        used in its place (and reported via ``backfill_field`` /
+        ``backfill_value`` so it can be synced on save).
+
         Args:
             model_list: List of model classes to process (None = all registered models)
             only_empty: If True, only gather fields with empty target language values
@@ -133,7 +148,12 @@ class ModeltranslationBackend:
                 - field: Source field name
                 - target_field: Target language field name
                 - source_text: Text to translate
+                - backfill_field: Default-language field name to sync from the
+                  original column when translations are applied (or None)
+                - backfill_value: Value for backfill_field (or None)
         """
+        from django.db.models import Q
+
         models = model_list or self.get_all_registered_models()
         translatable_items = []
 
@@ -143,28 +163,19 @@ class ModeltranslationBackend:
             for field_name in fields:
                 target_field = self.get_target_field_name(field_name)
 
-                # Get all available languages from settings
-                from django.conf import settings
-                from django.db.models import Q
+                source_langs = [
+                    lang for lang in self.available_langs if lang != self.target_lang
+                ]
 
-                # Get available languages from modeltranslation or Django settings
-                if hasattr(settings, "MODELTRANSLATION_LANGUAGES"):
-                    available_langs = list(settings.MODELTRANSLATION_LANGUAGES)
-                elif hasattr(settings, "LANGUAGES"):
-                    available_langs = [lang_code for lang_code, _ in settings.LANGUAGES]
-                else:
-                    # Fallback: just use target language (edge case)
-                    available_langs = [self.target_lang]
+                # If no source languages available, skip this field
+                if not source_langs:
+                    continue
 
                 # Build OR query: at least one language field must have content
                 # (excluding the target language field)
                 q_has_content = Q()
-                source_langs = [
-                    lang for lang in available_langs if lang != self.target_lang
-                ]
-
                 for lang in source_langs:
-                    lang_field = f"{field_name}_{lang}"
+                    lang_field = self._localized_fieldname(field_name, lang)
                     # Add condition: this language field is not null AND not empty
                     q_has_content |= Q(**{f"{lang_field}__isnull": False}) & ~Q(
                         **{f"{lang_field}__exact": ""}
@@ -176,10 +187,6 @@ class ModeltranslationBackend:
                     q_has_content |= Q(**{f"{field_name}__isnull": False}) & ~Q(
                         **{f"{field_name}__exact": ""}
                     )
-
-                # If no source languages available, skip this field
-                if not source_langs:
-                    continue
 
                 # Base queryset: at least one source language field has content.
                 # Disable modeltranslation's lookup rewriting so the original
@@ -196,24 +203,41 @@ class ModeltranslationBackend:
                         | Q(**{f"{target_field}__exact": ""})
                     )
 
+                if self.target_lang == self.default_lang:
+                    # The original column IS the default-language value.
+                    # A row with content there already has its target text;
+                    # machine-translating it from another (possibly machine-
+                    # translated) language column would only degrade it.
+                    queryset = queryset.filter(
+                        Q(**{f"{field_name}__isnull": True})
+                        | Q(**{f"{field_name}__exact": ""})
+                    )
+
                 for instance in queryset:
-                    # Get source text from the first populated language field
+                    # Get source text from the first populated language field.
+                    # The default language checks the original column as well:
+                    # it holds the default-language value for rows never saved
+                    # through the modeltranslation descriptor.
                     source_text = None
+                    backfill_field = None
+                    backfill_value = None
                     for lang in source_langs:
-                        lang_field = f"{field_name}_{lang}"
+                        lang_field = self._localized_fieldname(field_name, lang)
                         text = getattr(instance, lang_field, None)
+                        if not text and lang == self.default_lang:
+                            # Read the original column from __dict__ to bypass
+                            # the descriptor, which would resolve to the
+                            # active language instead of the raw column value.
+                            text = instance.__dict__.get(field_name)
+                            if text:
+                                # Sync the default-language column on save,
+                                # like modeltranslation's
+                                # update_translation_fields command does.
+                                backfill_field = lang_field
+                                backfill_value = text
                         if text:  # Found a populated source field
                             source_text = text
                             break
-
-                    if not source_text and self.default_lang in source_langs:
-                        # Last resort: the original column, which holds the
-                        # default-language value for rows never saved through
-                        # the modeltranslation descriptor. Read it from
-                        # __dict__ to bypass the descriptor, which would
-                        # resolve to the active language instead of the raw
-                        # column value.
-                        source_text = instance.__dict__.get(field_name)
 
                     if source_text:
                         translatable_items.append(
@@ -223,6 +247,8 @@ class ModeltranslationBackend:
                                 "field": field_name,
                                 "target_field": target_field,
                                 "source_text": str(source_text),
+                                "backfill_field": backfill_field,
+                                "backfill_value": backfill_value,
                             }
                         )
 
@@ -237,6 +263,9 @@ class ModeltranslationBackend:
                 - instance: Model instance
                 - target_field: Target field name
                 - translation: Translated text
+                - backfill_field (optional): Default-language field to sync
+                  from the original column alongside the translation
+                - backfill_value (optional): Value for backfill_field
             dry_run: If True, don't actually save to database
 
         Returns:
@@ -250,7 +279,7 @@ class ModeltranslationBackend:
         # consolidate onto one canonical instance per (model, pk). Passing
         # duplicate pks to bulk_update would let one copy's stale loaded
         # values overwrite another copy's translation.
-        by_model = defaultdict(dict)  # model -> pk -> (instance, {fields})
+        by_model = defaultdict(dict)  # model -> pk -> row dict
 
         for item in translation_items:
             instance = item["instance"]
@@ -258,20 +287,32 @@ class ModeltranslationBackend:
             translation = item["translation"]
 
             rows = by_model[instance.__class__]
-            canonical, fields = rows.setdefault(instance.pk, (instance, set()))
+            row = rows.setdefault(
+                instance.pk,
+                {"instance": instance, "translated": set(), "write_fields": set()},
+            )
+            canonical = row["instance"]
             setattr(canonical, target_field, translation)
-            fields.add(target_field)
+            row["translated"].add(target_field)
+            row["write_fields"].add(target_field)
 
-        # Bulk update per model, grouping rows by the exact set of translated
+            backfill_field = item.get("backfill_field")
+            if backfill_field:
+                setattr(canonical, backfill_field, item["backfill_value"])
+                row["write_fields"].add(backfill_field)
+
+        # Bulk update per model, grouping rows by the exact set of written
         # fields: updating a broader field set would write stale values into
         # fields that were translated in an earlier batch.
+        updated_count = 0
         for model_cls, rows in by_model.items():
             field_groups = defaultdict(list)  # frozenset(fields) -> [instances]
-            for canonical, fields in rows.values():
-                field_groups[frozenset(fields)].append(canonical)
+            for row in rows.values():
+                field_groups[frozenset(row["write_fields"])].append(row["instance"])
+                updated_count += len(row["translated"])
 
             with transaction.atomic():
                 for fields, instances in field_groups.items():
                     model_cls.objects.bulk_update(instances, list(fields))
 
-        return len(translation_items)
+        return updated_count

--- a/src/translatebot_django/backends/modeltranslation.py
+++ b/src/translatebot_django/backends/modeltranslation.py
@@ -4,6 +4,17 @@ from collections import defaultdict
 
 from django.apps import apps
 from django.db import transaction
+from django.db.models import F, FileField, Q
+
+
+def _q_has_content(field):
+    """Q clause matching rows where the column is non-null and non-empty."""
+    return Q(**{f"{field}__isnull": False}) & ~Q(**{f"{field}__exact": ""})
+
+
+def _q_is_empty(field):
+    """Q clause matching rows where the column is null or empty."""
+    return Q(**{f"{field}__isnull": True}) | Q(**{f"{field}__exact": ""})
 
 
 class ModeltranslationBackend:
@@ -127,15 +138,28 @@ class ModeltranslationBackend:
 
         return parsed_models
 
+    def _plain_queryset(self, model):
+        """
+        Queryset with modeltranslation's lookup rewriting disabled, so
+        original-column conditions and updates aren't redirected to the
+        active language. A custom manager may return a plain QuerySet
+        without ``rewrite``; that needs no disabling.
+        """
+        queryset = model.objects.all()
+        if hasattr(queryset, "rewrite"):
+            queryset = queryset.rewrite(False)
+        return queryset
+
     def gather_translatable_content(self, model_list=None, only_empty=True):
         """
         Gather all model field content that needs translation.
 
-        The default-language source is resolved the way modeltranslation's
-        ``update_translation_fields`` command would: when the
-        ``<field>_<default_lang>`` column is empty, the original column is
-        used in its place (and reported via ``backfill_field`` /
-        ``backfill_value`` so it can be synced on save).
+        The default language is the preferred source — the other languages'
+        columns may themselves be machine translations. Its value is
+        resolved the way modeltranslation's ``update_translation_fields``
+        command would: when the ``<field>_<default_lang>`` column is empty,
+        the original column is used in its place (and reported via
+        ``backfill_field`` so it can be synced on save).
 
         Args:
             model_list: List of model classes to process (None = all registered models)
@@ -148,91 +172,82 @@ class ModeltranslationBackend:
                 - field: Source field name
                 - target_field: Target language field name
                 - source_text: Text to translate
-                - backfill_field: Default-language field name to sync from the
-                  original column when translations are applied (or None)
-                - backfill_value: Value for backfill_field (or None)
+                - backfill_field: Default-language field name to sync with
+                  the source text when translations are applied (or None)
         """
-        from django.db.models import FileField, Q
-
         models = model_list or self.get_all_registered_models()
+        # Dedupe, preserving order: duplicate --models arguments (e.g.
+        # "Article tests.Article") resolve to the same class and would
+        # otherwise emit every item twice.
+        models = list(dict.fromkeys(models))
+
+        source_langs = [
+            lang for lang in self.available_langs if lang != self.target_lang
+        ]
+        if not source_langs:
+            return []
+        # Nothing guarantees the default language is listed first in
+        # AVAILABLE_LANGUAGES, so order it first explicitly.
+        if self.default_lang in source_langs:
+            source_langs.remove(self.default_lang)
+            source_langs.insert(0, self.default_lang)
+
         translatable_items = []
 
         for model in models:
-            fields = self.get_translatable_fields(model)
-
-            for field_name in fields:
-                target_field = self.get_target_field_name(field_name)
-
-                # The original column of a FileField/ImageField holds a raw
-                # path string; shipping it to a translation provider would
-                # write prose into file columns. Only text content may fall
-                # back to the original column.
-                original_is_text = not isinstance(
-                    model._meta.get_field(field_name), FileField
-                )
-
-                source_langs = [
-                    lang for lang in self.available_langs if lang != self.target_lang
-                ]
-
-                # If no source languages available, skip this field
-                if not source_langs:
+            for field_name in self.get_translatable_fields(model):
+                # A FileField/ImageField column — original or per-language —
+                # holds a raw path string; shipping one to a translation
+                # provider would write prose into file columns.
+                if isinstance(model._meta.get_field(field_name), FileField):
                     continue
 
-                # Build OR query: at least one language field must have content
-                # (excluding the target language field)
-                q_has_content = Q()
-                for lang in source_langs:
-                    lang_field = self._localized_fieldname(field_name, lang)
-                    # Add condition: this language field is not null AND not empty
-                    q_has_content |= Q(**{f"{lang_field}__isnull": False}) & ~Q(
-                        **{f"{lang_field}__exact": ""}
-                    )
+                target_field = self.get_target_field_name(field_name)
+                lang_fields = [
+                    self._localized_fieldname(field_name, lang) for lang in source_langs
+                ]
+
+                # Build OR query: at least one source language field must
+                # have content
+                q_content = Q()
+                for lang_field in lang_fields:
+                    q_content |= _q_has_content(lang_field)
 
                 # The original column holds the default-language value for
                 # rows never saved through the modeltranslation descriptor.
-                if self.default_lang in source_langs and original_is_text:
-                    q_has_content |= Q(**{f"{field_name}__isnull": False}) & ~Q(
-                        **{f"{field_name}__exact": ""}
-                    )
+                if self.default_lang in source_langs:
+                    q_content |= _q_has_content(field_name)
 
-                # Base queryset: at least one source language field has content.
-                # Disable modeltranslation's lookup rewriting so the original
-                # column condition isn't redirected to the active language.
-                queryset = model.objects.all()
-                if hasattr(queryset, "rewrite"):
-                    queryset = queryset.rewrite(False)
-                queryset = queryset.filter(q_has_content)
+                # Narrow the query to the columns actually read; field_name
+                # must stay in the list because the fallback below reads it
+                # from __dict__, where deferred columns are absent.
+                queryset = self._plain_queryset(model).only(
+                    field_name, target_field, *lang_fields
+                )
+                queryset = queryset.filter(q_content)
 
                 if only_empty:
                     # Only translate where target field is empty or null
-                    queryset = queryset.filter(
-                        Q(**{f"{target_field}__isnull": True})
-                        | Q(**{f"{target_field}__exact": ""})
-                    )
+                    queryset = queryset.filter(_q_is_empty(target_field))
 
                 if self.target_lang == self.default_lang:
                     # The original column IS the default-language value.
                     # A row with content there already has its target text;
                     # machine-translating it from another (possibly machine-
                     # translated) language column would only degrade it.
-                    queryset = queryset.filter(
-                        Q(**{f"{field_name}__isnull": True})
-                        | Q(**{f"{field_name}__exact": ""})
-                    )
+                    queryset = queryset.filter(_q_is_empty(field_name))
 
                 for instance in queryset:
-                    # Get source text from the first populated language field.
-                    # The default language checks the original column as well:
-                    # it holds the default-language value for rows never saved
-                    # through the modeltranslation descriptor.
+                    # Get source text from the first populated language
+                    # field, default language first. The default language
+                    # checks the original column as well: it holds the
+                    # default-language value for rows never saved through
+                    # the modeltranslation descriptor.
                     source_text = None
                     backfill_field = None
-                    backfill_value = None
-                    for lang in source_langs:
-                        lang_field = self._localized_fieldname(field_name, lang)
+                    for lang, lang_field in zip(source_langs, lang_fields, strict=True):
                         text = getattr(instance, lang_field, None)
-                        if not text and lang == self.default_lang and original_is_text:
+                        if not text and lang == self.default_lang:
                             # Read the original column from __dict__ to bypass
                             # the descriptor, which would resolve to the
                             # active language instead of the raw column value.
@@ -242,7 +257,6 @@ class ModeltranslationBackend:
                                 # like modeltranslation's
                                 # update_translation_fields command does.
                                 backfill_field = lang_field
-                                backfill_value = text
                         if text:  # Found a populated source field
                             source_text = text
                             break
@@ -256,7 +270,6 @@ class ModeltranslationBackend:
                                 "target_field": target_field,
                                 "source_text": str(source_text),
                                 "backfill_field": backfill_field,
-                                "backfill_value": backfill_value,
                             }
                         )
 
@@ -271,16 +284,41 @@ class ModeltranslationBackend:
                 - instance: Model instance
                 - target_field: Target field name
                 - translation: Translated text
-                - backfill_field (optional): Default-language field to sync
-                  from the original column alongside the translation
-                - backfill_value (optional): Value for backfill_field
+                - field (optional): Source field name; when translating into
+                  the default language it is used to keep the original
+                  column in sync with the new default-language value
+                - backfill_field (optional): Default-language field to fill
+                  with the item's source text; requires source_text
+                - source_text (optional): Source text the translation was
+                  made from, written to backfill_field
             dry_run: If True, don't actually save to database
 
         Returns:
-            int: Number of model fields updated
+            int: Number of distinct model fields updated (duplicate items
+            for the same row and field count once)
         """
+        # Validate before mutating any instance, so a bad item can't leave
+        # earlier items half-applied in memory.
+        for item in translation_items:
+            if item.get("backfill_field") and item.get("source_text") is None:
+                raise ValueError(
+                    "translation item with backfill_field "
+                    f"'{item['backfill_field']}' is missing source_text"
+                )
+
         if dry_run:
-            return len(translation_items)
+            # Report what a real run would write: duplicate items for the
+            # same row and field collapse into a single update.
+            return len(
+                {
+                    (
+                        item["instance"].__class__,
+                        getattr(item["instance"], "pk", None),
+                        item["target_field"],
+                    )
+                    for item in translation_items
+                }
+            )
 
         # The same DB row appears as a separate instance per translated field
         # (gather_translatable_content runs one queryset per field), so first
@@ -292,35 +330,58 @@ class ModeltranslationBackend:
         for item in translation_items:
             instance = item["instance"]
             target_field = item["target_field"]
-            translation = item["translation"]
 
             rows = by_model[instance.__class__]
             row = rows.setdefault(
                 instance.pk,
-                {"instance": instance, "translated": set(), "write_fields": set()},
+                {
+                    "instance": instance,
+                    "translated": set(),
+                    "write_fields": set(),
+                    "mirror_fields": set(),
+                },
             )
             canonical = row["instance"]
-            setattr(canonical, target_field, translation)
+            setattr(canonical, target_field, item["translation"])
             row["translated"].add(target_field)
             row["write_fields"].add(target_field)
 
             backfill_field = item.get("backfill_field")
             if backfill_field:
-                setattr(canonical, backfill_field, item["backfill_value"])
+                setattr(canonical, backfill_field, item["source_text"])
                 row["write_fields"].add(backfill_field)
 
-        # Bulk update per model, grouping rows by the exact set of written
-        # fields: updating a broader field set would write stale values into
-        # fields that were translated in an earlier batch.
+            # When translating INTO the default language, the original
+            # column — the authoritative default-language store — must
+            # receive the new value as well. bulk_update can't write it
+            # safely (reading the field goes through the modeltranslation
+            # descriptor, which resolves to the active language), so mirror
+            # it with a raw column-to-column UPDATE below.
+            field_name = item.get("field")
+            if field_name and self.target_lang == self.default_lang:
+                row["mirror_fields"].add((field_name, target_field))
+
         updated_count = 0
         for model_cls, rows in by_model.items():
-            field_groups = defaultdict(list)  # frozenset(fields) -> [instances]
+            # Group instances per written field: each bulk_update then
+            # writes exactly one explicitly-set column, so no instance can
+            # leak a stale loaded value into a field it wasn't translated
+            # for (e.g. one already translated in an earlier batch).
+            field_groups = defaultdict(list)  # field -> [instances]
+            mirror_groups = defaultdict(list)  # (field, target_field) -> [pks]
             for row in rows.values():
-                field_groups[frozenset(row["write_fields"])].append(row["instance"])
                 updated_count += len(row["translated"])
+                for field in row["write_fields"]:
+                    field_groups[field].append(row["instance"])
+                for mirror in row["mirror_fields"]:
+                    mirror_groups[mirror].append(row["instance"].pk)
 
             with transaction.atomic():
-                for fields, instances in field_groups.items():
-                    model_cls.objects.bulk_update(instances, list(fields))
+                for field, instances in field_groups.items():
+                    model_cls.objects.bulk_update(instances, [field])
+                for (field_name, target_field), pks in mirror_groups.items():
+                    self._plain_queryset(model_cls).filter(pk__in=pks).update(
+                        **{field_name: F(target_field)}
+                    )
 
         return updated_count

--- a/src/translatebot_django/backends/modeltranslation.py
+++ b/src/translatebot_django/backends/modeltranslation.py
@@ -152,7 +152,7 @@ class ModeltranslationBackend:
                   original column when translations are applied (or None)
                 - backfill_value: Value for backfill_field (or None)
         """
-        from django.db.models import Q
+        from django.db.models import FileField, Q
 
         models = model_list or self.get_all_registered_models()
         translatable_items = []
@@ -162,6 +162,14 @@ class ModeltranslationBackend:
 
             for field_name in fields:
                 target_field = self.get_target_field_name(field_name)
+
+                # The original column of a FileField/ImageField holds a raw
+                # path string; shipping it to a translation provider would
+                # write prose into file columns. Only text content may fall
+                # back to the original column.
+                original_is_text = not isinstance(
+                    model._meta.get_field(field_name), FileField
+                )
 
                 source_langs = [
                     lang for lang in self.available_langs if lang != self.target_lang
@@ -183,7 +191,7 @@ class ModeltranslationBackend:
 
                 # The original column holds the default-language value for
                 # rows never saved through the modeltranslation descriptor.
-                if self.default_lang in source_langs:
+                if self.default_lang in source_langs and original_is_text:
                     q_has_content |= Q(**{f"{field_name}__isnull": False}) & ~Q(
                         **{f"{field_name}__exact": ""}
                     )
@@ -224,7 +232,7 @@ class ModeltranslationBackend:
                     for lang in source_langs:
                         lang_field = self._localized_fieldname(field_name, lang)
                         text = getattr(instance, lang_field, None)
-                        if not text and lang == self.default_lang:
+                        if not text and lang == self.default_lang and original_is_text:
                             # Read the original column from __dict__ to bypass
                             # the descriptor, which would resolve to the
                             # active language instead of the raw column value.

--- a/src/translatebot_django/backends/modeltranslation.py
+++ b/src/translatebot_django/backends/modeltranslation.py
@@ -16,10 +16,17 @@ class ModeltranslationBackend:
         Args:
             target_lang: Target language code (e.g., 'de', 'nl', 'fr')
         """
+        from modeltranslation import settings as mt_settings
         from modeltranslation.translator import translator
 
         self.translator = translator
         self.target_lang = target_lang
+        # modeltranslation stores the default-language value in the original
+        # column; the <field>_<default_lang> column is only a mirror that gets
+        # synced on descriptor-mediated saves. Rows created before
+        # modeltranslation was installed (or written via update()/imports)
+        # have their default-language content only in the original column.
+        self.default_lang = mt_settings.DEFAULT_LANGUAGE
 
     def get_all_registered_models(self):
         """
@@ -163,12 +170,24 @@ class ModeltranslationBackend:
                         **{f"{lang_field}__exact": ""}
                     )
 
+                # The original column holds the default-language value for
+                # rows never saved through the modeltranslation descriptor.
+                if self.default_lang in source_langs:
+                    q_has_content |= Q(**{f"{field_name}__isnull": False}) & ~Q(
+                        **{f"{field_name}__exact": ""}
+                    )
+
                 # If no source languages available, skip this field
                 if not source_langs:
                     continue
 
-                # Base queryset: at least one source language field has content
-                queryset = model.objects.filter(q_has_content)
+                # Base queryset: at least one source language field has content.
+                # Disable modeltranslation's lookup rewriting so the original
+                # column condition isn't redirected to the active language.
+                queryset = model.objects.all()
+                if hasattr(queryset, "rewrite"):
+                    queryset = queryset.rewrite(False)
+                queryset = queryset.filter(q_has_content)
 
                 if only_empty:
                     # Only translate where target field is empty or null
@@ -186,6 +205,15 @@ class ModeltranslationBackend:
                         if text:  # Found a populated source field
                             source_text = text
                             break
+
+                    if not source_text and self.default_lang in source_langs:
+                        # Last resort: the original column, which holds the
+                        # default-language value for rows never saved through
+                        # the modeltranslation descriptor. Read it from
+                        # __dict__ to bypass the descriptor, which would
+                        # resolve to the active language instead of the raw
+                        # column value.
+                        source_text = instance.__dict__.get(field_name)
 
                     if source_text:
                         translatable_items.append(
@@ -212,35 +240,38 @@ class ModeltranslationBackend:
             dry_run: If True, don't actually save to database
 
         Returns:
-            int: Number of instances updated
+            int: Number of model fields updated
         """
         if dry_run:
             return len(translation_items)
 
-        # Group by model for efficient bulk_update
-        by_model = defaultdict(lambda: {"instances": [], "fields": set()})
+        # The same DB row appears as a separate instance per translated field
+        # (gather_translatable_content runs one queryset per field), so first
+        # consolidate onto one canonical instance per (model, pk). Passing
+        # duplicate pks to bulk_update would let one copy's stale loaded
+        # values overwrite another copy's translation.
+        by_model = defaultdict(dict)  # model -> pk -> (instance, {fields})
 
         for item in translation_items:
             instance = item["instance"]
             target_field = item["target_field"]
             translation = item["translation"]
 
-            # Set the translation on the instance
-            setattr(instance, target_field, translation)
+            rows = by_model[instance.__class__]
+            canonical, fields = rows.setdefault(instance.pk, (instance, set()))
+            setattr(canonical, target_field, translation)
+            fields.add(target_field)
 
-            # Track for bulk update
-            model_cls = instance.__class__
-            by_model[model_cls]["instances"].append(instance)
-            by_model[model_cls]["fields"].add(target_field)
-
-        # Bulk update by model
-        updated_count = 0
-        for model_cls, data in by_model.items():
-            instances = data["instances"]
-            fields = list(data["fields"])
+        # Bulk update per model, grouping rows by the exact set of translated
+        # fields: updating a broader field set would write stale values into
+        # fields that were translated in an earlier batch.
+        for model_cls, rows in by_model.items():
+            field_groups = defaultdict(list)  # frozenset(fields) -> [instances]
+            for canonical, fields in rows.values():
+                field_groups[frozenset(fields)].append(canonical)
 
             with transaction.atomic():
-                model_cls.objects.bulk_update(instances, fields)
-                updated_count += len(instances)
+                for fields, instances in field_groups.items():
+                    model_cls.objects.bulk_update(instances, list(fields))
 
-        return updated_count
+        return len(translation_items)

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -937,6 +937,8 @@ class Command(BaseCommand):
                                 "instance": item["instance"],
                                 "target_field": item["target_field"],
                                 "translation": translation,
+                                "backfill_field": item.get("backfill_field"),
+                                "backfill_value": item.get("backfill_value"),
                             }
                         )
 

--- a/src/translatebot_django/management/commands/translate.py
+++ b/src/translatebot_django/management/commands/translate.py
@@ -932,15 +932,10 @@ class Command(BaseCommand):
                     batch_items = []
                     pairs = zip(items_group, translations, strict=True)
                     for item, translation in pairs:
-                        batch_items.append(
-                            {
-                                "instance": item["instance"],
-                                "target_field": item["target_field"],
-                                "translation": translation,
-                                "backfill_field": item.get("backfill_field"),
-                                "backfill_value": item.get("backfill_value"),
-                            }
-                        )
+                        # Pass the gathered item through whole: apply needs
+                        # field/source_text for original-column syncing on
+                        # top of instance/target_field/backfill_field.
+                        batch_items.append({**item, "translation": translation})
 
                         model_name = item["model"].__name__
                         field_name = item["field"]

--- a/tests/models.py
+++ b/tests/models.py
@@ -28,3 +28,16 @@ class Product(models.Model):
 
     def __str__(self):
         return self.name
+
+
+class Document(models.Model):
+    """Test model with a translated file field."""
+
+    name = models.CharField(max_length=100)
+    attachment = models.FileField(upload_to="docs/", blank=True)
+
+    class Meta:
+        app_label = "tests"
+
+    def __str__(self):
+        return self.name

--- a/tests/test_modeltranslation.py
+++ b/tests/test_modeltranslation.py
@@ -194,7 +194,8 @@ def test_gather_content_with_modeltranslation_languages(settings):
     """Test gathering content when MODELTRANSLATION_LANGUAGES is set."""
     from translatebot_django.backends.modeltranslation import ModeltranslationBackend
 
-    # Set MODELTRANSLATION_LANGUAGES (takes priority over LANGUAGES)
+    # The backend reads modeltranslation's import-time language list (the
+    # languages it created columns for); runtime overrides are ignored.
     settings.MODELTRANSLATION_LANGUAGES = ("en", "de", "nl")
 
     backend = ModeltranslationBackend(target_lang="nl")
@@ -213,7 +214,8 @@ def test_gather_content_without_languages_settings(settings):
     """Test gathering content without MODELTRANSLATION_LANGUAGES or LANGUAGES."""
     from translatebot_django.backends.modeltranslation import ModeltranslationBackend
 
-    # Remove both settings to test fallback
+    # Remove both settings at runtime; the backend keeps working because it
+    # uses modeltranslation's import-time language list
     if hasattr(settings, "MODELTRANSLATION_LANGUAGES"):
         delattr(settings, "MODELTRANSLATION_LANGUAGES")
     if hasattr(settings, "LANGUAGES"):
@@ -222,7 +224,6 @@ def test_gather_content_without_languages_settings(settings):
     backend = ModeltranslationBackend(target_lang="nl")
     items = backend.gather_translatable_content()
 
-    # Should use target_lang as fallback and return a list
     assert isinstance(items, list)
 
 
@@ -236,9 +237,6 @@ def test_gather_content_no_source_languages(settings):
     from tests.models import Article
     from translatebot_django.backends.modeltranslation import ModeltranslationBackend
 
-    # Set LANGUAGES to only include the target language
-    settings.LANGUAGES = [("nl", "Dutch")]
-
     # Create an article with some content
     Article.objects.create(
         title="Test Title",
@@ -246,8 +244,12 @@ def test_gather_content_no_source_languages(settings):
     )
 
     backend = ModeltranslationBackend(target_lang="nl")
+    # Simulate a setup where the only available language is the target
+    # (modeltranslation's language list is frozen at import, so patch the
+    # backend's copy)
+    backend.available_langs = ["nl"]
     items = backend.gather_translatable_content()
 
     # Should return empty list because there are no source languages
     # (all available languages == target language, so source_langs is empty)
-    assert isinstance(items, list)
+    assert items == []

--- a/tests/test_modeltranslation_full.py
+++ b/tests/test_modeltranslation_full.py
@@ -209,6 +209,9 @@ class TestModeltranslationBackendWithDB:
             def rewrite(self, mode=True):
                 return self
 
+            def only(self, *fields):
+                return self
+
             def filter(self, *args, **kwargs):
                 return self
 
@@ -234,6 +237,9 @@ class TestModeltranslationBackendWithDB:
         # Fake queryset lacking rewrite(), as returned by a custom manager
         # whose get_queryset() doesn't use MultilingualQuerySet
         class FakeQuerySet:
+            def only(self, *fields):
+                return self
+
             def filter(self, *args, **kwargs):
                 return self
 
@@ -272,23 +278,23 @@ class TestModeltranslationBackendWithDB:
         assert by_field["content"]["source_text"] == "Legacy Content"
         # Legacy rows are marked for default-language backfill on save
         assert by_field["title"]["backfill_field"] == "title_en"
-        assert by_field["title"]["backfill_value"] == "Legacy Title"
 
-    def test_backend_original_column_fallback_skips_file_fields(self):
-        """The original column of a FileField holds a raw path string; it
-        must never be shipped to a translation provider (which would write
-        prose into file columns). Text fields still fall back."""
+    def test_backend_gather_skips_file_fields_entirely(self):
+        """Any FileField column — original or per-language — holds a raw
+        path string; none may ever be shipped to a translation provider
+        (which would write prose into file columns). Text fields still
+        fall back to the original column."""
         from tests.models import Document
 
         backend = ModeltranslationBackend(target_lang="nl")
 
         doc = Document.objects.create(name="Manual", attachment="docs/manual.pdf")
-        # Simulate legacy data: language columns empty, values only in the
-        # original columns
+        # Text language columns empty (legacy row); the per-language file
+        # column populated, as the descriptor sync produces on every save
         Document.objects.filter(pk=doc.pk).update(
             name_en=None,
             name_de=None,
-            attachment_en=None,
+            attachment_en="docs/manual.pdf",
             attachment_de=None,
         )
 
@@ -314,15 +320,7 @@ class TestModeltranslationBackendWithDB:
         title_item = next(i for i in items if i["field"] == "title")
 
         backend.apply_translations(
-            [
-                {
-                    "instance": title_item["instance"],
-                    "target_field": title_item["target_field"],
-                    "translation": "NL Titel",
-                    "backfill_field": title_item["backfill_field"],
-                    "backfill_value": title_item["backfill_value"],
-                }
-            ],
+            [{**title_item, "translation": "NL Titel"}],
             dry_run=False,
         )
 
@@ -359,7 +357,100 @@ class TestModeltranslationBackendWithDB:
         assert legacy.pk not in title_items
         assert title_items[dutch_only.pk]["source_text"] == "Alleen Nederlands"
 
-    def test_backend_original_column_used_at_default_language_position(self):
+    def test_backend_apply_syncs_original_column_at_default_language(self):
+        """Translating INTO the default language must also fill the original
+        column — the authoritative default-language store for raw SQL,
+        .values() and rewrite(False) consumers. Otherwise the row would
+        also be re-matched (and re-translated) on every overwrite run."""
+        backend = ModeltranslationBackend(target_lang="en")
+
+        article = Article.objects.create(title="tmp", content="c")
+        Article.objects.filter(pk=article.pk).rewrite(False).update(
+            title="", title_en=None, title_nl="Alleen Nederlands"
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+        title_item = next(i for i in items if i["field"] == "title")
+
+        backend.apply_translations(
+            [{**title_item, "translation": "English Title"}],
+            dry_run=False,
+        )
+
+        assert (
+            Article.objects.filter(pk=article.pk)
+            .rewrite(False)
+            .values_list("title_en", flat=True)
+            .get()
+            == "English Title"
+        )
+        # The raw original column received the same value
+        assert (
+            Article.objects.filter(pk=article.pk)
+            .rewrite(False)
+            .values_list("title", flat=True)
+            .get()
+            == "English Title"
+        )
+
+    def test_backend_apply_backfill_field_requires_source_text(self):
+        """An item carrying backfill_field but no source_text is rejected
+        up front with a clear error instead of failing mid-apply."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(title="Hello", content="World")
+
+        with pytest.raises(ValueError, match="missing source_text"):
+            backend.apply_translations(
+                [
+                    {
+                        "instance": article,
+                        "target_field": "title_nl",
+                        "translation": "Hallo",
+                        "backfill_field": "title_en",
+                    }
+                ],
+                dry_run=False,
+            )
+
+    def test_backend_gather_dedupes_duplicate_models(self):
+        """--models 'Article tests.Article' resolves to the same class twice;
+        gather must not emit every item twice."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        Article.objects.create(title="Hello", content="World")
+
+        once = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+        twice = backend.gather_translatable_content(
+            model_list=[Article, Article], only_empty=True
+        )
+        assert len(twice) == len(once)
+
+    def test_backend_apply_dry_run_matches_real_run_on_duplicates(self):
+        """Duplicate items for the same row and field collapse into one
+        write, and the dry-run count reports the same number."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(title="Hello", content="World")
+        duplicated = [
+            {"instance": article, "target_field": "title_nl", "translation": "Hallo"},
+            {"instance": article, "target_field": "title_nl", "translation": "Hallo"},
+        ]
+
+        dry = backend.apply_translations(duplicated, dry_run=True)
+        real = backend.apply_translations(duplicated, dry_run=False)
+        assert dry == real == 1
+
+    def test_backend_apply_translations_empty_real_run(self):
+        """An empty item list is a no-op for a real run, not just dry-run."""
+        backend = ModeltranslationBackend(target_lang="nl")
+        assert backend.apply_translations([], dry_run=False) == 0
+
+    def test_backend_original_column_outranks_other_languages(self):
         """When the default-language column is empty, the original column is
         used in its place (mirroring update_translation_fields), so the
         default-language original outranks other languages' columns — which
@@ -378,7 +469,32 @@ class TestModeltranslationBackendWithDB:
         title_items = [i for i in items if i["field"] == "title"]
         assert title_items[0]["source_text"] == "Original English"
         assert title_items[0]["backfill_field"] == "title_en"
-        assert title_items[0]["backfill_value"] == "Original English"
+
+    def test_backend_default_language_preferred_regardless_of_lang_order(self):
+        """The default language must be the preferred source even when it
+        is not listed first in AVAILABLE_LANGUAGES (modeltranslation only
+        requires it to be IN the list): other columns may themselves be
+        machine translations."""
+        backend = ModeltranslationBackend(target_lang="nl")
+        # Simulate LANGUAGES listing the default ('en') after 'de'
+        # (modeltranslation's list is frozen at import, so patch the
+        # backend's copy)
+        backend.available_langs = ["de", "en", "nl"]
+
+        article = Article.objects.create(title="Original English", content="c")
+        Article.objects.filter(pk=article.pk).update(
+            title_en=None, title_de="Maschinell übersetzt"
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+
+        title_items = [i for i in items if i["field"] == "title"]
+        # The pristine original-column English wins over the German column,
+        # and the legacy row is still marked for backfill
+        assert title_items[0]["source_text"] == "Original English"
+        assert title_items[0]["backfill_field"] == "title_en"
 
     def test_backend_apply_translations_multiple_fields_same_row(self):
         """Regression test for #251: gather returns a separate instance copy

--- a/tests/test_modeltranslation_full.py
+++ b/tests/test_modeltranslation_full.py
@@ -246,6 +246,32 @@ class TestModeltranslationBackendWithDB:
         assert by_field["title"]["backfill_field"] == "title_en"
         assert by_field["title"]["backfill_value"] == "Legacy Title"
 
+    def test_backend_original_column_fallback_skips_file_fields(self):
+        """The original column of a FileField holds a raw path string; it
+        must never be shipped to a translation provider (which would write
+        prose into file columns). Text fields still fall back."""
+        from tests.models import Document
+
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        doc = Document.objects.create(name="Manual", attachment="docs/manual.pdf")
+        # Simulate legacy data: language columns empty, values only in the
+        # original columns
+        Document.objects.filter(pk=doc.pk).update(
+            name_en=None,
+            name_de=None,
+            attachment_en=None,
+            attachment_de=None,
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Document], only_empty=True
+        )
+
+        fields = {item["field"] for item in items}
+        assert "name" in fields  # text falls back to the original column
+        assert "attachment" not in fields  # file path is never a source text
+
     def test_backend_apply_translations_backfills_default_language(self):
         """Applying a translation sourced from the original column also syncs
         the default-language column, like update_translation_fields would."""

--- a/tests/test_modeltranslation_full.py
+++ b/tests/test_modeltranslation_full.py
@@ -222,6 +222,34 @@ class TestModeltranslationBackendWithDB:
         )
         assert len(items) == 0
 
+    def test_backend_gather_handles_queryset_without_rewrite(self, mocker):
+        """A custom manager may return a plain QuerySet without
+        modeltranslation's rewrite(); gathering must still work."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(
+            title="Plain QS Title", content="Plain QS Content"
+        )
+
+        # Fake queryset lacking rewrite(), as returned by a custom manager
+        # whose get_queryset() doesn't use MultilingualQuerySet
+        class FakeQuerySet:
+            def filter(self, *args, **kwargs):
+                return self
+
+            def __iter__(self):
+                return iter([article])
+
+        mocker.patch.object(Article.objects, "all", return_value=FakeQuerySet())
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=False
+        )
+
+        source_texts = {item["source_text"] for item in items}
+        assert "Plain QS Title" in source_texts
+        assert "Plain QS Content" in source_texts
+
     def test_backend_gather_finds_legacy_rows_original_column_only(self):
         """Regression test for #251: rows whose content lives only in the
         original column (e.g. data predating modeltranslation, never passed

--- a/tests/test_modeltranslation_full.py
+++ b/tests/test_modeltranslation_full.py
@@ -202,11 +202,20 @@ class TestModeltranslationBackendWithDB:
                 setattr(article, f"{field}_{lang}", None)
             article.__dict__[field] = None
 
-        # Mock the queryset chain to return our empty article, simulating a
-        # TOCTOU where data changed after the queryset filter
-        queryset = mocker.MagicMock()
-        queryset.rewrite.return_value.filter.return_value = [article]
-        mocker.patch.object(Article.objects, "all", return_value=queryset)
+        # Fake queryset that yields our empty article no matter how the
+        # chain is composed, simulating a TOCTOU where data changed after
+        # the queryset filter
+        class FakeQuerySet:
+            def rewrite(self, mode=True):
+                return self
+
+            def filter(self, *args, **kwargs):
+                return self
+
+            def __iter__(self):
+                return iter([article])
+
+        mocker.patch.object(Article.objects, "all", return_value=FakeQuerySet())
 
         items = backend.gather_translatable_content(
             model_list=[Article], only_empty=False
@@ -230,16 +239,80 @@ class TestModeltranslationBackendWithDB:
             model_list=[Article], only_empty=True
         )
 
-        by_field = {item["field"]: item["source_text"] for item in items}
-        assert by_field["title"] == "Legacy Title"
-        assert by_field["content"] == "Legacy Content"
+        by_field = {item["field"]: item for item in items}
+        assert by_field["title"]["source_text"] == "Legacy Title"
+        assert by_field["content"]["source_text"] == "Legacy Content"
+        # Legacy rows are marked for default-language backfill on save
+        assert by_field["title"]["backfill_field"] == "title_en"
+        assert by_field["title"]["backfill_value"] == "Legacy Title"
 
-    def test_backend_language_columns_beat_original_column(self):
-        """An explicit language column takes priority over the original
-        column, which may hold a stale default-language mirror."""
+    def test_backend_apply_translations_backfills_default_language(self):
+        """Applying a translation sourced from the original column also syncs
+        the default-language column, like update_translation_fields would."""
         backend = ModeltranslationBackend(target_lang="nl")
 
-        article = Article.objects.create(title="Stale original", content="c")
+        article = Article.objects.create(title="Legacy Title", content="c")
+        Article.objects.filter(pk=article.pk).update(title_en=None)
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+        title_item = next(i for i in items if i["field"] == "title")
+
+        backend.apply_translations(
+            [
+                {
+                    "instance": title_item["instance"],
+                    "target_field": title_item["target_field"],
+                    "translation": "NL Titel",
+                    "backfill_field": title_item["backfill_field"],
+                    "backfill_value": title_item["backfill_value"],
+                }
+            ],
+            dry_run=False,
+        )
+
+        article.refresh_from_db()
+        assert article.title_nl == "NL Titel"
+        assert article.title_en == "Legacy Title"  # backfilled
+
+    def test_backend_gather_target_is_default_language(self):
+        """When translating INTO the default language, rows whose original
+        column already holds the (default-language) value are skipped instead
+        of being relay-translated from another language column; rows without
+        it are translated from the other languages."""
+        backend = ModeltranslationBackend(target_lang="en")
+
+        # Row 1: pristine English in the original column, Dutch machine
+        # translation present. Must NOT be re-generated from Dutch.
+        legacy = Article.objects.create(title="tmp", content="c")
+        Article.objects.filter(pk=legacy.pk).rewrite(False).update(
+            title="Pristine English", title_en=None, title_nl="Machine Dutch"
+        )
+
+        # Row 2: no English anywhere, Dutch content only. Should be
+        # translated from Dutch.
+        dutch_only = Article.objects.create(title="tmp2", content="c")
+        Article.objects.filter(pk=dutch_only.pk).rewrite(False).update(
+            title="", title_en=None, title_nl="Alleen Nederlands"
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+
+        title_items = {i["instance"].pk: i for i in items if i["field"] == "title"}
+        assert legacy.pk not in title_items
+        assert title_items[dutch_only.pk]["source_text"] == "Alleen Nederlands"
+
+    def test_backend_original_column_used_at_default_language_position(self):
+        """When the default-language column is empty, the original column is
+        used in its place (mirroring update_translation_fields), so the
+        default-language original outranks other languages' columns — which
+        may themselves be machine translations."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(title="Original English", content="c")
         Article.objects.filter(pk=article.pk).update(
             title_en=None, title_de="Deutscher Titel"
         )
@@ -249,7 +322,9 @@ class TestModeltranslationBackendWithDB:
         )
 
         title_items = [i for i in items if i["field"] == "title"]
-        assert title_items[0]["source_text"] == "Deutscher Titel"
+        assert title_items[0]["source_text"] == "Original English"
+        assert title_items[0]["backfill_field"] == "title_en"
+        assert title_items[0]["backfill_value"] == "Original English"
 
     def test_backend_apply_translations_multiple_fields_same_row(self):
         """Regression test for #251: gather returns a separate instance copy
@@ -325,12 +400,17 @@ class TestModeltranslationBackendWithDB:
         # target_lang="nl", so source_langs = ["en", "de"]
         backend = ModeltranslationBackend(target_lang="nl")
 
-        # Create article with en empty but de populated
+        # Create article with en (language column AND original column, which
+        # stands in for the default language) empty but de populated.
+        # rewrite(False) keeps modeltranslation from redirecting the plain
+        # field names to the active language.
         article = Article.objects.create(title="placeholder", content="placeholder")
-        Article.objects.filter(pk=article.pk).update(
+        Article.objects.filter(pk=article.pk).rewrite(False).update(
+            title="",
             title_en="",
             title_de="Deutscher Titel",
             title_nl="",
+            content="",
             content_en="",
             content_de="Deutscher Inhalt",
             content_nl="",

--- a/tests/test_modeltranslation_full.py
+++ b/tests/test_modeltranslation_full.py
@@ -134,8 +134,7 @@ class TestModeltranslationBackendWithDB:
         # Apply translations
         updated = backend.apply_translations(translation_items, dry_run=False)
 
-        # The function counts instances in the list, which includes the same
-        # instance twice
+        # The function counts translated fields
         assert updated == 2
 
         # Verify translations were applied
@@ -195,26 +194,131 @@ class TestModeltranslationBackendWithDB:
         """Test that instances with no populated source fields are skipped."""
         backend = ModeltranslationBackend(target_lang="nl")
 
-        # Create an article, then null out all source language fields
+        # Create an article, then empty out every source of content in memory:
+        # all language fields and the original columns
         article = Article.objects.create(title="tmp", content="tmp")
-        Article.objects.filter(pk=article.pk).update(
-            title_en=None,
-            title_de=None,
-            content_en=None,
-            content_de=None,
-            description_en=None,
-            description_de=None,
-        )
-        article.refresh_from_db()
+        for field in ("title", "content", "description"):
+            for lang in ("en", "de"):
+                setattr(article, f"{field}_{lang}", None)
+            article.__dict__[field] = None
 
-        # Mock filter to return our empty article, simulating a TOCTOU
-        # where data changed after the queryset filter
-        mocker.patch.object(Article.objects, "filter", return_value=[article])
+        # Mock the queryset chain to return our empty article, simulating a
+        # TOCTOU where data changed after the queryset filter
+        queryset = mocker.MagicMock()
+        queryset.rewrite.return_value.filter.return_value = [article]
+        mocker.patch.object(Article.objects, "all", return_value=queryset)
 
         items = backend.gather_translatable_content(
             model_list=[Article], only_empty=False
         )
         assert len(items) == 0
+
+    def test_backend_gather_finds_legacy_rows_original_column_only(self):
+        """Regression test for #251: rows whose content lives only in the
+        original column (e.g. data predating modeltranslation, never passed
+        through update_translation_fields) must still be discovered."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(title="Legacy Title", content="Legacy Content")
+        # Simulate legacy data: language columns empty, content only in the
+        # original columns (queryset.update() bypasses the descriptor sync)
+        Article.objects.filter(pk=article.pk).update(
+            title_en=None, title_de=None, content_en=None, content_de=None
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+
+        by_field = {item["field"]: item["source_text"] for item in items}
+        assert by_field["title"] == "Legacy Title"
+        assert by_field["content"] == "Legacy Content"
+
+    def test_backend_language_columns_beat_original_column(self):
+        """An explicit language column takes priority over the original
+        column, which may hold a stale default-language mirror."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(title="Stale original", content="c")
+        Article.objects.filter(pk=article.pk).update(
+            title_en=None, title_de="Deutscher Titel"
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+
+        title_items = [i for i in items if i["field"] == "title"]
+        assert title_items[0]["source_text"] == "Deutscher Titel"
+
+    def test_backend_apply_translations_multiple_fields_same_row(self):
+        """Regression test for #251: gather returns a separate instance copy
+        per field for the same row; applying them together must not let one
+        copy's stale values clobber another copy's translation."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        article = Article.objects.create(
+            title="Hello", content="World", description="Desc"
+        )
+
+        items = backend.gather_translatable_content(
+            model_list=[Article], only_empty=True
+        )
+        assert len(items) == 3
+
+        translation_items = [
+            {
+                "instance": item["instance"],
+                "target_field": item["target_field"],
+                "translation": f"NL {item['source_text']}",
+            }
+            for item in items
+        ]
+        updated = backend.apply_translations(translation_items, dry_run=False)
+        assert updated == 3
+
+        article.refresh_from_db()
+        assert article.title_nl == "NL Hello"
+        assert article.content_nl == "NL World"
+        assert article.description_nl == "NL Desc"
+
+    def test_backend_apply_translations_preserves_other_rows_fields(self):
+        """A bulk update for one row's fields must not write another row's
+        stale values for fields it wasn't translated for (e.g. a field
+        already translated in an earlier batch)."""
+        backend = ModeltranslationBackend(target_lang="nl")
+
+        a = Article.objects.create(title="A title", content="A content")
+        b = Article.objects.create(title="B title", content="B content")
+
+        # Instance copies as gather_translatable_content would produce them
+        a_copy = Article.objects.get(pk=a.pk)
+        b_copy = Article.objects.get(pk=b.pk)
+
+        # Simulate an earlier batch having already translated a.content_nl
+        Article.objects.filter(pk=a.pk).update(content_nl="Earlier translation")
+
+        backend.apply_translations(
+            [
+                {
+                    "instance": a_copy,
+                    "target_field": "title_nl",
+                    "translation": "NL A title",
+                },
+                {
+                    "instance": b_copy,
+                    "target_field": "content_nl",
+                    "translation": "NL B content",
+                },
+            ],
+            dry_run=False,
+        )
+
+        a.refresh_from_db()
+        b.refresh_from_db()
+        assert a.title_nl == "NL A title"
+        assert a.content_nl == "Earlier translation"  # not clobbered
+        assert b.content_nl == "NL B content"
 
     def test_backend_gather_skips_empty_first_source_lang(self):
         """Test that gather falls through to second source lang when first is empty."""

--- a/tests/translation.py
+++ b/tests/translation.py
@@ -2,7 +2,7 @@
 
 from modeltranslation.translator import TranslationOptions, register
 
-from .models import Article, Product
+from .models import Article, Document, Product
 
 
 @register(Article)
@@ -13,3 +13,8 @@ class ArticleTranslationOptions(TranslationOptions):
 @register(Product)
 class ProductTranslationOptions(TranslationOptions):
     fields = ("name", "description")
+
+
+@register(Document)
+class DocumentTranslationOptions(TranslationOptions):
+    fields = ("name", "attachment")


### PR DESCRIPTION
Fixes two bugs in the modeltranslation backend reported in #251, where only some registered fields were discovered and even fewer translations actually reached the database.
