### PR TITLE
chore: have dependabot skip litellm while the Python 3.10 cap is in p…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # litellm is capped per Python version (see pyproject.toml) while
+      # https://github.com/BerriAI/litellm/issues/38076 is unfixed; dependabot
+      # cannot resolve the marker split, so bump litellm manually with
+      # `uv lock --upgrade-package litellm` and remove this once fixed.
+      - dependency-name: "litellm"
     groups:
       minor-and-patch:
         patterns: ["*"]


### PR DESCRIPTION
…lace

Dependabot pins both halves of the marker-split litellm requirement to the same new version, which conflicts with the < 1.98 cap for Python 3.10 and makes its uv resolution fail. Ignore litellm in dependabot and bump it manually (uv lock --upgrade-package litellm) until https://github.com/BerriAI/litellm/issues/38076 is fixed upstream, then drop both the cap and this ignore.